### PR TITLE
Israel Radar: select leading video only from Israel subset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3111,16 +3111,6 @@ function buildIsraelRadarInsight(data = {}) {
   }
 
   if (!israelVideos.length) {
-    const bestAvailableSignal = scoredVideos
-      .filter((row) => row.signal.score > 0)
-      .sort((a, b) => b.signal.score - a.signal.score);
-
-    if (bestAvailableSignal.length) {
-      israelVideos.push(bestAvailableSignal[0]);
-    }
-  }
-
-  if (!israelVideos.length) {
     return {
       hasSignal: false,
       title: "Not enough Israel-specific signal yet",
@@ -3136,7 +3126,18 @@ function buildIsraelRadarInsight(data = {}) {
     return bScore - aScore;
   });
 
-  const leader = ranked[0]?.video;
+  const leaderRow = ranked.find((row) => row.signal.score >= ISRAEL_SIGNAL_THRESHOLD);
+  if (!leaderRow) {
+    return {
+      hasSignal: false,
+      title: "Not enough Israel-specific signal yet",
+      leadLine: "Top Trend in Israel: —",
+      summary: "Waiting for stronger IL/Hebrew/local BBQ cues.",
+      videoUrl: ""
+    };
+  }
+
+  const leader = leaderRow.video;
   const trendSignals = ranked.flatMap((row) => row.signal.keywordMatches);
   const trendCounts = trendSignals.reduce((acc, keyword) => {
     acc[keyword] = (acc[keyword] || 0) + 1;


### PR DESCRIPTION
### Motivation
- The Leading Video could be chosen from the global dataset while the Top Trend was Israel-based, causing inconsistent Israel Radar output; the goal is to ensure all Israel Radar outputs come strictly from Israel-related items.

### Description
- Removed the global `bestAvailableSignal` fallback that previously injected a non-Israel candidate so the Israel radar is constrained to the Israel subset and seed fallback only (change applied in `public/index.html` around L3095-L3121).
- Added a leader safeguard to select the leading video only from `ranked` entries whose `signal.score` meets `ISRAEL_SIGNAL_THRESHOLD`, and return the existing Israel fallback state if no qualifying leader exists (change applied in `public/index.html` around L3129-L3140).
- Ensured `Top Trend` calculation and the Leading Video are both derived from the `israelVideos` / `ranked` pipeline so trend and video remain consistent.
- Kept the change minimal and logic-only with no UI, layout, or unrelated logic modifications.

### Testing
- Ran `node --check server.js` which completed without errors.
- No other automated tests exist for this component and therefore were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e234d1ba74832fbd6c9ba888f2ff4e)