### PR TITLE
Add base PostHog installation snippet to index head

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1845,6 +1845,12 @@
   grid-column: 1 / -1;
 }
   </style>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('phc_pqdNbg2fWwDwQYwndvhi6Whpaij9oJazXv3Fig2gARoK', {
+      api_host: 'https://us.i.posthog.com'
+    })
+  </script>
 </head>
 <body>
   <div class="opening-loader" id="openingLoader">


### PR DESCRIPTION
### Motivation
- Add PostHog base installation to enable future analytics while making the minimal change possible. 
- Keep all existing logic, styling, function names, and behavior unchanged by only inserting the standard snippet. 
- Use the provided PostHog project key and `api_host` for immediate readiness without enabling any events.

### Description
- Inserted the standard PostHog snippet into `public/index.html` inside the `<head>` tag immediately before `</head>`. 
- Configured the snippet with project key `phc_pqdNbg2fWwDwQYwndvhi6Whpaij9oJazXv3Fig2gARoK` and `api_host: 'https://us.i.posthog.com'`. 
- No other files were modified, and no refactors, logic changes, renames, styling changes, events, or helper functions were added.

### Testing
- Ran the insertion script which wrote the updated file and printed `updated`, and that step succeeded. 
- Verified the change with `git diff -- public/index.html` which showed only the snippet insertion and succeeded. 
- Confirmed repository state with `git status --short` and committed the change with `git commit`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e289df889c832fbd7013f57ea63130)