### PR TITLE
Fix PostHog snippet with official asset-host loader

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1845,12 +1845,13 @@
   grid-column: 1 / -1;
 }
   </style>
-  <script>
-    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('phc_pqdNbg2fWwDwQYwndvhi6Whpaij9oJazXv3Fig2gARoK', {
-      api_host: 'https://us.i.posthog.com'
-    })
-  </script>
+<script>
+!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once people.unset people.increment people.append people.remove people.track_charge people.clear_charges people.delete_user".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+
+posthog.init('phc_pqdNbg2fWwDwQYwndvhi6Whpaij9oJazXv3Fig2gARoK', {
+  api_host: 'https://us.i.posthog.com'
+});
+</script>
 </head>
 <body>
   <div class="opening-loader" id="openingLoader">


### PR DESCRIPTION
### Motivation
- The existing PostHog snippet in the page head was incomplete/modified and caused 404/401 errors when loading analytics assets.

### Description
- Replaced only the PostHog script snippet inside `<head>` in `public/index.html` with the official loader that uses `api_host.replace(".i.posthog.com","-assets.i.posthog.com")` to load `/static/array.js` and retained the existing project key and `api_host` setting.
- No other files or code were modified and no refactors or event additions were made.

### Testing
- No automated tests were run for this change (static HTML snippet replacement only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28d9abc94832f8f4749a757e28ccf)