### PR TITLE
Add OG/Twitter metadata and update share copy text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Smoke Radar</title>
+  <meta property="og:title" content="Smoke Radar – Live Meat Trend Dashboard" />
+  <meta property="og:description" content="Discover the hottest BBQ and meat videos, trending cuts, butcher spots, and live smoke signals in one dashboard." />
+  <meta property="og:image" content="https://smoke-radar.onrender.com/og-preview.jpg" />
+  <meta property="og:url" content="https://smoke-radar.onrender.com/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Smoke Radar" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Smoke Radar – Live Meat Trend Dashboard" />
+  <meta name="twitter:description" content="Discover the hottest BBQ and meat videos, trending cuts, butcher spots, and live smoke signals in one dashboard." />
+  <meta name="twitter:image" content="https://smoke-radar.onrender.com/og-preview.jpg" />
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
@@ -4069,11 +4079,12 @@ const data = isJson ? await res.json() : null;
     function setupShareButton() {
       const shareBtn = document.getElementById("shareBtn");
       const shareToast = document.getElementById("shareToast");
+      const shareCopyText = "Check out Smoke Radar – live meat trend dashboard for BBQ, meat trends, cuts, and butcher discovery 🔥\nhttps://smoke-radar.onrender.com/";
       if (!shareBtn) return;
 
       shareBtn.addEventListener("click", async () => {
         try {
-          await navigator.clipboard.writeText(window.location.href);
+          await navigator.clipboard.writeText(shareCopyText);
           if (shareToast) {
             shareToast.classList.add("show");
             window.setTimeout(() => shareToast.classList.remove("show"), 1200);


### PR DESCRIPTION
### Motivation
- Improve social share previews and make the copied share text more informative without changing layout or telemetry.
- Keep changes minimal and preserve existing analytics events and behavior.

### Description
- Added Open Graph meta tags in `public/index.html` (`og:title`, `og:description`, `og:image`, `og:url`, `og:type`, `og:site_name`).
- Added Twitter meta tags in `public/index.html` (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`).
- Replaced the Share button clipboard payload with a branded multi-line string by adding `shareCopyText` and using `navigator.clipboard.writeText(shareCopyText)` in `setupShareButton()` in `public/index.html`.
- Left PostHog tracking unchanged so `copy_link_clicked` still fires after the copy action.

### Testing
- Verified tags and code changes with `rg -n "og:title|twitter:card|shareCopyText|copy_link_clicked|clipboard.writeText" public/index.html`, which found the new meta tags and updated share behavior (success).
- Committed the change with `git commit`, and confirmed the modified file is `public/index.html` (success).
- Printed surrounding lines with `nl` to visually confirm the inserted meta tags and `shareCopyText` usage (manual verification via automated command succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3059408a4832fa26f9e23dd12f9fd)