### PR TITLE
Upgrade Recipe Generator into Smart Cooking Mode with sauces & sides

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -237,6 +237,12 @@
       overflow: hidden;
     }
 
+    .pill-btn.secondary {
+      background: rgba(255,255,255,0.01);
+      color: #c9d6e6;
+      border-color: #2a3648;
+    }
+
     .small-btn {
       padding: 9px 12px;
       font-size: 12px;
@@ -794,7 +800,7 @@
 
     .recipe-output {
       border-radius: 22px;
-      padding: 16px;
+      padding: 18px;
     }
 
     .recipe-output h3 {
@@ -831,7 +837,7 @@
 
     .ai-recipe-wrap {
       display: grid;
-      gap: 14px;
+      gap: 16px;
     }
 
     .ai-recipe-header {
@@ -870,9 +876,9 @@
     .ai-recipe-card {
       border-radius: 18px;
       padding: 15px;
-      background: #101722;
+      background: linear-gradient(180deg, #111927, #101722);
       border: 1px solid #1b2534;
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.03), 0 0 18px rgba(255, 107, 44, 0.08);
     }
 
     .ai-recipe-card h4 {
@@ -910,6 +916,103 @@
       color: #dbe5f2;
       font-size: 12px;
       font-weight: 700;
+    }
+
+    .pairings-section {
+      display: grid;
+      gap: 10px;
+    }
+
+    .pairings-title {
+      margin: 0;
+      font-size: 14px;
+      color: #d8e2ef;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .sauce-grid,
+    .sides-grid {
+      display: grid;
+      gap: 10px;
+    }
+
+    .sauce-card {
+      border-radius: 16px;
+      border: 1px solid #243043;
+      background: #101722;
+      box-shadow: 0 0 16px rgba(255, 107, 44, 0.08);
+      overflow: hidden;
+    }
+
+    .sauce-toggle {
+      width: 100%;
+      background: transparent;
+      border: 0;
+      color: inherit;
+      text-align: left;
+      padding: 12px 14px;
+      display: flex;
+      justify-content: space-between;
+      gap: 10px;
+      cursor: pointer;
+    }
+
+    .sauce-toggle h5 {
+      margin: 0 0 4px;
+      font-size: 14px;
+      color: #ecf3ff;
+    }
+
+    .sauce-toggle p {
+      margin: 0;
+      color: #b7c6d8;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    .sauce-chevron {
+      color: #ff9c73;
+      font-size: 14px;
+      transition: transform 0.25s ease;
+      align-self: center;
+    }
+
+    .sauce-card.expanded .sauce-chevron {
+      transform: rotate(180deg);
+    }
+
+    .sauce-details {
+      max-height: 0;
+      overflow: hidden;
+      transition: max-height 0.3s ease;
+      padding: 0 14px;
+    }
+
+    .sauce-card.expanded .sauce-details {
+      max-height: 420px;
+      padding-bottom: 12px;
+    }
+
+    .side-card {
+      border-radius: 14px;
+      background: #101722;
+      border: 1px solid #223045;
+      padding: 10px 12px;
+      box-shadow: 0 0 14px rgba(255, 107, 44, 0.06);
+    }
+
+    .side-card h5 {
+      margin: 0 0 4px;
+      font-size: 14px;
+      color: #ecf3ff;
+    }
+
+    .side-card p {
+      margin: 0;
+      font-size: 13px;
+      color: #b7c6d8;
+      line-height: 1.5;
     }
 
     .butcher-toolbar {
@@ -1472,6 +1575,14 @@
 
       .ai-recipe-card.full {
         grid-column: 1 / -1;
+      }
+
+      .sauce-grid {
+        grid-template-columns: 1fr 1fr;
+      }
+
+      .sides-grid {
+        grid-template-columns: 1fr 1fr;
       }
          }
 
@@ -2386,7 +2497,9 @@
       </div>
 
       <div class="recipe-actions">
-        <button class="pill-btn" onclick="generateRecipe()">Generate Recipe</button>
+        <button class="pill-btn" onclick="generateRecipe('all')">Generate Recipe</button>
+        <button class="pill-btn secondary" onclick="generateRecipe('sauces')">Regenerate Sauces Only</button>
+        <button class="pill-btn secondary" onclick="generateRecipe('sides')">Regenerate Sides Only</button>
       </div>
 
       <div class="recipe-output" id="recipeOutput">
@@ -3896,7 +4009,9 @@ function updateBeefHighlight(cutName) {
       );
     }
 
-    async function generateRecipe() {
+    let latestStructuredRecipe = null;
+
+    async function generateRecipe(mode = "all") {
       const cut = document.getElementById("cutType").value;
       const method = document.getElementById("cookingMethod").value;
       const flavor = document.getElementById("flavorProfile").value;
@@ -3912,7 +4027,7 @@ function updateBeefHighlight(cutName) {
 
       try {
        const res = await fetch(
-  `/api/ai-recipe?cut=${encodeURIComponent(cut)}&method=${encodeURIComponent(method)}&flavor=${encodeURIComponent(flavor)}&r=${randomSeed}`
+  `/api/ai-recipe?cut=${encodeURIComponent(cut)}&method=${encodeURIComponent(method)}&flavor=${encodeURIComponent(flavor)}&r=${randomSeed}&mode=${encodeURIComponent(mode)}`
 );
 
 const contentType = res.headers.get("content-type") || "";
@@ -3937,8 +4052,12 @@ if (!isJson) {
 }
 
 const data = await res.json();
+const incomingStructured = normalizeStructuredRecipe(data.structuredRecipe);
+const mergedStructured = mergeStructuredRecipe(latestStructuredRecipe, incomingStructured, mode);
+latestStructuredRecipe = mergedStructured;
 
         output.innerHTML = renderAiRecipe(data.recipe, {
+          structuredRecipe: mergedStructured,
           cut,
           method,
           flavor,
@@ -3957,6 +4076,10 @@ const data = await res.json();
     }
 
     function renderAiRecipe(recipeText, meta = {}) {
+      if (meta.structuredRecipe) {
+        return renderSmartRecipe(meta.structuredRecipe, meta);
+      }
+
       const parsed = parseAiRecipe(recipeText);
 
       const ingredientsList = parsed.ingredients.length
@@ -4007,6 +4130,157 @@ const data = await res.json();
           </div>
         </div>
       `;
+    }
+
+    function normalizeStructuredRecipe(recipe) {
+      if (!recipe || typeof recipe !== "object") return null;
+
+      const safeList = (value) =>
+        Array.isArray(value)
+          ? value.map(item => String(item || "").trim()).filter(Boolean)
+          : [];
+
+      const safeSauces = Array.isArray(recipe.sauces)
+        ? recipe.sauces
+            .map((item) => ({
+              name: String(item?.name || "").trim(),
+              description: String(item?.description || "").trim(),
+              ingredients: safeList(item?.ingredients),
+              steps: safeList(item?.steps)
+            }))
+            .filter(item => item.name)
+            .slice(0, 3)
+        : [];
+
+      const safeSides = Array.isArray(recipe.sides)
+        ? recipe.sides
+            .map((item) => ({
+              name: String(item?.name || "").trim(),
+              description: String(item?.description || "").trim()
+            }))
+            .filter(item => item.name)
+            .slice(0, 3)
+        : [];
+
+      return {
+        main: {
+          title: String(recipe?.main?.title || "").trim(),
+          description: String(recipe?.main?.description || "").trim(),
+          ingredients: safeList(recipe?.main?.ingredients),
+          steps: safeList(recipe?.main?.steps)
+        },
+        sauces: safeSauces,
+        sides: safeSides
+      };
+    }
+
+    function mergeStructuredRecipe(currentRecipe, incomingRecipe, mode = "all") {
+      if (!incomingRecipe) return currentRecipe;
+      if (!currentRecipe || mode === "all") return incomingRecipe;
+
+      if (mode === "sauces") {
+        return {
+          ...currentRecipe,
+          sauces: incomingRecipe.sauces.length ? incomingRecipe.sauces : currentRecipe.sauces
+        };
+      }
+
+      if (mode === "sides") {
+        return {
+          ...currentRecipe,
+          sides: incomingRecipe.sides.length ? incomingRecipe.sides : currentRecipe.sides
+        };
+      }
+
+      return incomingRecipe;
+    }
+
+    function renderSmartRecipe(structuredRecipe, meta = {}) {
+      const main = structuredRecipe?.main || {};
+      const mainIngredients = (main.ingredients || []).length
+        ? `<ul>${(main.ingredients || []).map(item => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`
+        : `<p>Ingredients not provided.</p>`;
+
+      const mainSteps = (main.steps || []).length
+        ? `<ol>${(main.steps || []).map(item => `<li>${escapeHtml(item)}</li>`).join("")}</ol>`
+        : `<p>Steps not provided.</p>`;
+
+      const sauceCards = (structuredRecipe.sauces || []).map((sauce, index) => `
+        <article class="sauce-card" id="sauceCard${index}">
+          <button class="sauce-toggle" type="button" onclick="toggleSauceCard(${index})">
+            <div>
+              <h5>${escapeHtml(sauce.name)}</h5>
+              <p>${escapeHtml(sauce.description)}</p>
+            </div>
+            <span class="sauce-chevron">⌄</span>
+          </button>
+          <div class="sauce-details">
+            <h4>Ingredients</h4>
+            <ul>${(sauce.ingredients || []).map(item => `<li>${escapeHtml(item)}</li>`).join("")}</ul>
+            <h4>Steps</h4>
+            <ol>${(sauce.steps || []).map(item => `<li>${escapeHtml(item)}</li>`).join("")}</ol>
+          </div>
+        </article>
+      `).join("");
+
+      const sidesCards = (structuredRecipe.sides || []).map((side) => `
+        <article class="side-card">
+          <h5>${escapeHtml(side.name)}</h5>
+          <p>${escapeHtml(side.description)}</p>
+        </article>
+      `).join("");
+
+      return `
+        <div class="ai-recipe-wrap">
+          <div class="ai-recipe-header">
+            <h3 class="ai-recipe-title">${escapeHtml(main.title || "Smart Cooking Mode")}</h3>
+            <span class="ai-recipe-badge">${escapeHtml(meta.source || "ai")} powered</span>
+          </div>
+
+          <div class="ai-recipe-meta">
+            <span class="ai-recipe-chip">🥩 ${escapeHtml(meta.cut || "cut")}</span>
+            <span class="ai-recipe-chip">🔥 ${escapeHtml(meta.method || "method")}</span>
+            <span class="ai-recipe-chip">🧂 ${escapeHtml(meta.flavor || "flavor")}</span>
+          </div>
+
+          <div class="ai-recipe-grid">
+            <div class="ai-recipe-card full">
+              <h4>Main Recipe</h4>
+              <p>${escapeHtml(main.description || "No description provided.")}</p>
+            </div>
+
+            <div class="ai-recipe-card">
+              <h4>Ingredients</h4>
+              ${mainIngredients}
+            </div>
+
+            <div class="ai-recipe-card">
+              <h4>Steps</h4>
+              ${mainSteps}
+            </div>
+          </div>
+
+          <section class="pairings-section">
+            <h4 class="pairings-title">🔥 Sauce Pairings</h4>
+            <div class="sauce-grid">
+              ${sauceCards || "<p>No sauce pairings available.</p>"}
+            </div>
+          </section>
+
+          <section class="pairings-section">
+            <h4 class="pairings-title">🍽️ Perfect Sides</h4>
+            <div class="sides-grid">
+              ${sidesCards || "<p>No side suggestions available.</p>"}
+            </div>
+          </section>
+        </div>
+      `;
+    }
+
+    function toggleSauceCard(index) {
+      const card = document.getElementById(`sauceCard${index}`);
+      if (!card) return;
+      card.classList.toggle("expanded");
     }
 
     function parseAiRecipe(recipeText = "") {

--- a/server.js
+++ b/server.js
@@ -662,8 +662,171 @@ app.get("/api/smoke-radar", async (req, res) => {
 });
 
 app.get("/api/ai-recipe", async (req, res) => {
+  const sanitizeStringList = (value, fallback = []) =>
+    Array.isArray(value)
+      ? value
+          .map(item => String(item || "").trim())
+          .filter(Boolean)
+      : fallback;
+
+  const sanitizeObjectList = (value) =>
+    Array.isArray(value) ? value.filter(item => item && typeof item === "object") : [];
+
+  const toSeedNumber = (value) => {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : Date.now();
+  };
+
+  const buildFallbackSmartRecipe = ({ cut, method, flavor, seed }) => {
+    const sauces = [
+      {
+        name: "Smoky Garlic Butter",
+        description: "Rich and glossy, great for basting and finishing slices.",
+        ingredients: [
+          "3 tbsp unsalted butter",
+          "1 minced garlic clove",
+          "1 tsp smoked paprika",
+          "Pinch of salt",
+          "1 tsp lemon juice"
+        ],
+        steps: [
+          "Melt butter on low heat.",
+          "Stir in garlic and paprika for 30 seconds.",
+          "Add salt and lemon juice, then serve warm."
+        ]
+      },
+      {
+        name: "Pepper Mustard Glaze",
+        description: "Tangy with a little heat, ideal for bark-heavy cuts.",
+        ingredients: [
+          "2 tbsp Dijon mustard",
+          "1 tbsp honey",
+          "1 tsp cracked black pepper",
+          "1 tsp apple cider vinegar"
+        ],
+        steps: [
+          "Whisk all ingredients until smooth.",
+          "Brush lightly in the final minutes of cooking.",
+          "Serve extra on the side."
+        ]
+      },
+      {
+        name: "Herb Chimichurri",
+        description: "Fresh, sharp, and bright to balance rich meat.",
+        ingredients: [
+          "1 cup chopped parsley",
+          "2 tbsp chopped oregano",
+          "2 minced garlic cloves",
+          "3 tbsp red wine vinegar",
+          "1/3 cup olive oil"
+        ],
+        steps: [
+          "Mix herbs and garlic in a bowl.",
+          "Add vinegar and oil, then season with salt.",
+          "Let rest 10 minutes before serving."
+        ]
+      }
+    ];
+
+    const sides = [
+      {
+        name: "Charred Corn with Lime",
+        description: "Sweet smoky kernels with citrus lift."
+      },
+      {
+        name: "Crispy Herb Potatoes",
+        description: "Golden bite-size potatoes with rosemary and sea salt."
+      },
+      {
+        name: "Grilled Asparagus",
+        description: "Quick blistered greens with olive oil and pepper."
+      }
+    ];
+
+    const sauceShift = toSeedNumber(seed) % sauces.length;
+    const sideShift = toSeedNumber(seed) % sides.length;
+
+    return {
+      main: {
+        title: `${flavor || "Bold"} ${cut || "Meat"} (${method || "Cooked"})`,
+        description: `A concise ${flavor || "savory"} main recipe built for ${method || "high-heat cooking"}.`,
+        ingredients: [
+          `${cut || "Main cut"} (about 2 lb)`,
+          "Kosher salt",
+          "Black pepper",
+          "2 tbsp neutral oil",
+          `1 tsp ${flavor || "signature"} seasoning`
+        ],
+        steps: [
+          `Preheat for ${method || "your method"} and season the meat evenly.`,
+          "Cook until crust forms, then manage heat to finish evenly.",
+          "Rest 8-10 minutes, slice, and serve."
+        ]
+      },
+      sauces: [sauces[sauceShift], sauces[(sauceShift + 1) % sauces.length], sauces[(sauceShift + 2) % sauces.length]],
+      sides: [sides[sideShift], sides[(sideShift + 1) % sides.length], sides[(sideShift + 2) % sides.length]]
+    };
+  };
+
+  const normalizeSmartRecipe = (payload, context = {}) => {
+    const fallback = buildFallbackSmartRecipe(context);
+    const normalized = payload && typeof payload === "object" ? payload : {};
+
+    const main = normalized.main && typeof normalized.main === "object" ? normalized.main : {};
+
+    const sauces = sanitizeObjectList(normalized.sauces).map((entry) => {
+      const item = entry && typeof entry === "object" ? entry : {};
+      return {
+        name: String(item.name || "Sauce pairing").trim(),
+        description: String(item.description || "Complements the main recipe.").trim(),
+        ingredients: sanitizeStringList(item.ingredients),
+        steps: sanitizeStringList(item.steps)
+      };
+    }).filter(item => item.name);
+
+    const sides = sanitizeObjectList(normalized.sides).map((entry) => {
+      const item = entry && typeof entry === "object" ? entry : {};
+      return {
+        name: String(item.name || "Side dish").trim(),
+        description: String(item.description || "Quick supporting side.").trim()
+      };
+    }).filter(item => item.name);
+
+    const safeSauces = sauces.length >= 2 ? sauces.slice(0, 3) : fallback.sauces.slice(0, 3);
+    const safeSides = sides.length >= 2 ? sides.slice(0, 3) : fallback.sides.slice(0, 3);
+
+    return {
+      main: {
+        title: String(main.title || fallback.main.title).trim(),
+        description: String(main.description || fallback.main.description).trim(),
+        ingredients: sanitizeStringList(main.ingredients, fallback.main.ingredients).slice(0, 12),
+        steps: sanitizeStringList(main.steps, fallback.main.steps).slice(0, 8)
+      },
+      sauces: safeSauces.map((item, idx) => ({
+        name: item.name || fallback.sauces[idx]?.name || "Sauce pairing",
+        description: item.description || fallback.sauces[idx]?.description || "Complements the main recipe.",
+        ingredients: sanitizeStringList(item.ingredients, fallback.sauces[idx]?.ingredients || []).slice(0, 10),
+        steps: sanitizeStringList(item.steps, fallback.sauces[idx]?.steps || []).slice(0, 6)
+      })),
+      sides: safeSides.map((item, idx) => ({
+        name: item.name || fallback.sides[idx]?.name || "Side dish",
+        description: item.description || fallback.sides[idx]?.description || "Quick supporting side."
+      }))
+    };
+  };
+
+  const structuredToLegacyText = (structuredRecipe) => {
+    const main = structuredRecipe?.main || {};
+    const ingredients = (main.ingredients || []).map(item => `- ${item}`).join("\n");
+    const steps = (main.steps || []).map((item, idx) => `${idx + 1}. ${item}`).join("\n");
+    const sauceTips = (structuredRecipe?.sauces || []).map(item => `- ${item.name}: ${item.description}`).join("\n");
+    const sideTips = (structuredRecipe?.sides || []).map(item => `- ${item.name}: ${item.description}`).join("\n");
+
+    return `Title: ${main.title || "AI Recipe"}\nIngredients:\n${ingredients}\n\nSteps:\n${steps}\n\nTips:\n${sauceTips}\n${sideTips}\n\nTarget doneness:\nUse a thermometer and cook to preference.`;
+  };
+
   try {
-    const { cut, method, flavor, r } = req.query;
+    const { cut, method, flavor, r, mode = "all" } = req.query;
 
     if (!process.env.OPENAI_API_KEY) {
       return res.status(500).json({ error: "Missing OPENAI_API_KEY" });
@@ -672,36 +835,43 @@ app.get("/api/ai-recipe", async (req, res) => {
 const prompt = `
 You are a creative professional chef specializing in beef and meat dishes.
 
-Create a UNIQUE meat recipe every time.
+Create a concise Smart Cooking Mode response.
 
 Cut: ${cut}
 Cooking method: ${method}
 Flavor profile: ${flavor}
 Variation seed: ${r}
+Refresh mode: ${mode}
 
-Make it slightly different each time:
-- Change ingredients a bit
-- Change technique a bit
-- Change wording
-- Keep it practical and realistic
+Rules:
+- Keep copy concise and practical (no long paragraphs)
+- Return exactly 2-3 sauces
+- Return exactly 2-3 sides
+- Always return valid JSON only, no markdown
 
-Return the recipe in this exact structure:
-
-Title:
-Ingredients:
-- item
-- item
-
-Steps:
-1. step
-2. step
-
-Tips:
-- tip
-- tip
-
-Target doneness:
-...
+JSON shape:
+{
+  "main": {
+    "title": "string",
+    "description": "string",
+    "ingredients": ["string"],
+    "steps": ["string"]
+  },
+  "sauces": [
+    {
+      "name": "string",
+      "description": "string",
+      "ingredients": ["string"],
+      "steps": ["string"]
+    }
+  ],
+  "sides": [
+    {
+      "name": "string",
+      "description": "string"
+    }
+  ]
+}
 `;
 
     const completion = await openai.chat.completions.create({
@@ -715,11 +885,29 @@ Target doneness:
       temperature: 0.8
     });
 
-    const recipe = completion.choices?.[0]?.message?.content || "";
+    const recipeText = completion.choices?.[0]?.message?.content || "";
+    const normalizedRaw = recipeText.replace(/^```json\s*/i, "").replace(/^```\s*/i, "").replace(/\s*```$/i, "");
+    let parsedPayload = null;
+
+    try {
+      parsedPayload = JSON.parse(normalizedRaw);
+    } catch (parseError) {
+      parsedPayload = null;
+      console.warn("AI recipe JSON parse failed, using fallback shape.");
+    }
+
+    const structuredRecipe = normalizeSmartRecipe(parsedPayload, {
+      cut,
+      method,
+      flavor,
+      seed: r
+    });
+    const recipe = structuredToLegacyText(structuredRecipe);
 
     return res.json({
       recipe,
-      source: "ai"
+      structuredRecipe,
+      source: parsedPayload ? "ai" : "fallback"
     });
   } catch (err) {
     console.error("AI RECIPE ERROR:", err);


### PR DESCRIPTION
### Motivation
- Transform the basic Recipe Generator into a structured "Smart Cooking Mode" that returns a richer, actionable cooking experience (main recipe + sauce pairings + side suggestions). 
- Preserve existing behavior and compatibility by continuing to provide the legacy plain-text `recipe` output while adding a normalized `structuredRecipe` payload. 
- Allow scoped regenerations (sauces-only or sides-only) without wiping other generated sections and keep changes minimal and modular.

### Description
- Backend: updated `/api/ai-recipe` prompt to request strict JSON and accept a `mode` hint (`all|sauces|sides`), parse model output to JSON when possible, and normalize into the required shape with `main`, `sauces`, and `sides`; always ensure 2–3 concise sauces and 2–3 sides via seeded fallback data and sanitizers.  
- Backend: added helpers `normalizeSmartRecipe`, `buildFallbackSmartRecipe`, and `structuredToLegacyText` to enforce shape, guard lengths, sanitize lists, and produce the legacy `recipe` text for backward compatibility. 
- Frontend: added `normalizeStructuredRecipe`, `mergeStructuredRecipe`, `renderSmartRecipe`, and `toggleSauceCard` to render three sections immediately (Main Recipe, 🔥 Sauce Pairings, 🍽️ Perfect Sides) with expandable sauce cards and smooth animations while keeping the old parser path as a fallback. 
- UX/CSS: spacing tweaks and subtle glow/styling consistent with the dark premium theme, responsive sauce/side grids, and new buttons for `Regenerate Sauces Only` and `Regenerate Sides Only` wired to scoped API calls.

### Testing
- Ran `node --check server.js` to validate the server JavaScript syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4490f12c0832fadc9c43acda1fe11)