### PR TITLE
Refine Beef Cuts Explorer SVG regions for better cow-body coverage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2369,49 +2369,49 @@
         id="chuck"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 67 82 C 84 86, 95 88, 112 92 C 124 95, 131 93, 133 85 L 133 45 L 98 45 C 96 62, 90 77, 67 82 Z"
+        d="M 64 81 C 76 84, 93 88, 111 92 C 121 94, 128 92, 133 88 L 133 45 L 100 45 C 98 62, 91 75, 78 80 C 72 82, 67 82, 64 81 Z"
       />
       <path
         id="sirloin"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 213 43 L 250 41 L 258 97 L 220 99 Z"
+        d="M 214 43 L 249 41 L 257 96 L 224 100 L 219 89 L 216 71 Z"
       />
       <path
         id="picanha"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 246 41 L 289 38 L 292 57 L 243 60 Z"
+        d="M 248 41 L 289 38 L 295 56 L 284 63 L 247 60 Z"
       />
       <path
         id="ribeye"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 133 43 L 188 43 L 197 100 L 133 102 Z"
+        d="M 133 43 L 189 43 L 198 100 L 136 103 L 133 89 Z"
       />
       <path
         id="filet"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 188 43 L 211 42 L 219 99 L 198 103 Z"
+        d="M 188 43 L 214 42 L 223 100 L 201 104 L 196 92 Z"
       />
       <path
         id="brisket"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 86 100 L 134 103 L 145 136 L 116 141 C 104 139, 98 135, 96 128 C 93 118, 88 104, 86 100 Z"
+        d="M 85 99 L 136 103 L 148 136 L 119 143 C 106 141, 98 136, 94 129 C 91 121, 88 107, 85 99 Z"
       />
       <path
         id="short_ribs"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 136 102 L 212 100 L 214 132 C 198 133, 169 133, 145 137 Z"
+        d="M 136 102 L 214 100 L 219 133 C 200 135, 170 135, 145 137 Z"
       />
       <path
         id="flank"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 214 101 L 258 98 L 265 138 L 240 132 C 229 132, 220 135, 209 141 Z"
+        d="M 214 100 L 258 97 L 269 136 L 242 133 C 231 133, 221 136, 210 142 Z"
       />
     </g>
   </svg>


### PR DESCRIPTION
### Motivation
- The existing beef-cut paths felt like floating rectangular blocks and left some body areas poorly assigned, so the SVG region shapes were refined to better follow the cow silhouette while preserving all interaction and layout constraints.

### Description
- Adjusted only the SVG `d` path coordinates for these region `path` elements in `public/index.html`: `chuck`, `ribeye`, `sirloin`, `brisket`, `short_ribs`, `flank`, `filet`, and `picanha`.
- Kept all `id` attributes, classes, and surrounding markup unchanged so click/hover/highlight/card-sync logic continues to reference the same region keys.
- No layout, style, or interaction code was modified; this is a focused geometry/coverage pass only.

### Testing
- Ran `git diff -- public/index.html` to confirm only the intended `d` attributes changed, and `nl -ba public/index.html | sed -n '2360,2435p'` to review the updated block; both checks succeeded.
- Committed the change (`git commit`), which completed successfully and indicates a single-file focused change.
- No automated visual regression tests were present or run in this environment, so visual verification is recommended in-browser; no runtime or console-affecting changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b0b2b7c4832fb338fbaac447bdd3)