### PR TITLE
Add local PostHog internal/test user flag helpers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2121,7 +2121,28 @@
         defaults: '2026-01-30',
         person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
         capture_pageview: true
-    })
+    });
+
+    if (localStorage.getItem('smoke_radar_internal_tester') === 'true') {
+      if (typeof posthog.setInternalOrTestUser === 'function') {
+        posthog.setInternalOrTestUser(true);
+      }
+      posthog.register({
+        tester: true,
+        internal_user: true,
+        test_source: 'manual_local_flag'
+      });
+    }
+
+    window.enableSmokeRadarTestUser = function() {
+      localStorage.setItem('smoke_radar_internal_tester', 'true');
+      console.log('Smoke Radar: Test user ENABLED. Refresh page.');
+    };
+
+    window.disableSmokeRadarTestUser = function() {
+      localStorage.removeItem('smoke_radar_internal_tester');
+      console.log('Smoke Radar: Test user DISABLED. Refresh page.');
+    };
 </script> 
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Allow marking the current browser as an internal/test user via a local flag so activity can be filtered in PostHog without changing events, adding UI, or adding dependencies.

### Description
- In `public/index.html` immediately after `posthog.init(...)` added a check for `localStorage.getItem('smoke_radar_internal_tester') === 'true'` which calls `posthog.setInternalOrTestUser(true)` when available and registers the properties `tester: true`, `internal_user: true`, and `test_source: 'manual_local_flag'`, and also added the global helpers `window.enableSmokeRadarTestUser()` and `window.disableSmokeRadarTestUser()`.

### Testing
- Ran `git -C /workspace/Smoke-radar- status --short`, inspected the modified file region with `nl -ba /workspace/Smoke-radar-/public/index.html | sed -n '2115,2175p'`, and committed the change with `git -C /workspace/Smoke-radar- commit`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e661b2d9fc832fb904d0dca151e1ba)