### PR TITLE
Refine Beef Cuts Explorer SVG anatomy regions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2390,49 +2390,49 @@
         id="chuck"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 64 81 C 76 84, 93 88, 111 92 C 121 94, 128 92, 133 88 L 133 45 L 100 45 C 98 62, 91 75, 78 80 C 72 82, 67 82, 64 81 Z"
+        d="M 63 81 C 72 76, 83 69, 92 60 C 99 53, 103 48, 106 44 L 133 44 L 133 88 C 127 93, 119 95, 109 94 C 94 91, 80 87, 69 84 C 66 83, 64 82, 63 81 Z"
       />
       <path
         id="sirloin"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 214 43 L 249 41 L 257 96 L 224 100 L 219 89 L 216 71 Z"
+        d="M 211 43 L 245 41 L 252 51 L 256 66 L 258 82 L 258 95 L 226 99 L 221 90 L 217 76 L 214 60 Z"
       />
       <path
         id="picanha"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 248 41 L 289 38 L 295 56 L 284 63 L 247 60 Z"
+        d="M 245 41 L 287 38 L 295 47 L 296 57 L 288 63 L 273 64 L 256 62 L 249 54 Z"
       />
       <path
         id="ribeye"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 133 43 L 189 43 L 198 100 L 136 103 L 133 89 Z"
+        d="M 133 44 L 188 43 L 197 52 L 202 66 L 204 81 L 202 96 L 198 101 L 136 103 L 134 92 L 133 78 Z"
       />
       <path
         id="filet"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 188 43 L 214 42 L 223 100 L 201 104 L 196 92 Z"
+        d="M 188 43 L 211 43 L 214 57 L 218 73 L 222 89 L 224 100 L 202 104 L 198 96 L 194 82 L 191 66 Z"
       />
       <path
         id="brisket"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 85 99 L 136 103 L 148 136 L 119 143 C 106 141, 98 136, 94 129 C 91 121, 88 107, 85 99 Z"
+        d="M 85 99 L 136 103 L 148 116 L 150 129 L 141 139 L 122 144 C 110 143, 101 139, 95 131 C 91 122, 88 110, 85 99 Z"
       />
       <path
         id="short_ribs"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 136 102 L 214 100 L 219 133 C 200 135, 170 135, 145 137 Z"
+        d="M 136 103 L 198 101 L 224 100 L 225 113 L 223 126 L 220 133 C 202 136, 179 138, 160 138 C 151 138, 144 138, 139 137 Z"
       />
       <path
         id="flank"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 214 100 L 258 97 L 269 136 L 242 133 C 231 133, 221 136, 210 142 Z"
+        d="M 224 100 L 258 97 L 268 107 L 272 122 L 269 136 L 248 136 C 238 136, 229 138, 221 142 L 210 142 L 218 132 L 223 118 Z"
       />
     </g>
   </svg>


### PR DESCRIPTION
### Motivation
- Improve the anatomical accuracy of the Beef Cuts Explorer by updating the SVG cut regions to follow the provided Angus beef chart while leaving the UI and interactions unchanged.
- Keep all existing behavior (hover, click, highlight, card sync) intact by preserving region IDs and mapping logic.

### Description
- Replaced/refined the `d` path values for the cow cut regions in `public/index.html` to produce more organic, anatomically-aligned shapes for `chuck`, `ribeye`, `filet`, `sirloin`, `picanha`, `brisket`, `short_ribs`, and `flank` without changing element IDs or classes.
- No UI/layout changes or JavaScript logic edits were made; the `BEEF_CUTS` mapping, `REGION_TO_CUT_MAP`, `updateBeefHighlight`, and `attachBeefMapInteractions` remain unchanged to preserve interactions.
- Kept paths intentionally simple (clean curves and polygons) to balance accuracy and maintainability, avoiding over-complication.
- Note: shapes were tuned for better front/mid/rear alignment; further pixel-perfect tuning of curve control points or plate-to-flank seams can be done in a follow-up if needed.

### Testing
- Ran `node --check server.js` to validate server file syntax and it completed successfully.
- Verified the working tree and commit state with `git status --short` and committed the change as "Refine Beef Cuts Explorer SVG anatomy regions".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e5e33780832f917435b1bfa145a1)