### PR TITLE
Restore picanha and refactor beef-map SVG regions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2408,31 +2408,37 @@
         id="sirloin"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 212 42 L 246 40 C 254 47, 259 58, 261 72 C 263 84, 262 96, 258 106 L 225 104 C 229 95, 230 85, 228 74 C 225 60, 220 49, 212 42 Z"
+        d="M 212 42 L 240 40 C 248 46, 253 56, 255 70 C 257 81, 257 92, 252 101 L 226 103 C 229 93, 230 84, 228 74 C 226 61, 221 50, 212 42 Z"
+      />
+      <path
+        id="picanha"
+        class="cut-region"
+        style="stroke-width:0.264583"
+        d="M 240 40 L 263 39 C 271 44, 275 52, 276 63 C 277 71, 275 79, 270 86 L 260 90 L 252 101 C 257 92, 257 81, 255 70 C 253 56, 248 46, 240 40 Z"
       />
       <path
         id="round"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 246 40 L 286 38 C 293 44, 296 54, 296 67 C 296 81, 291 95, 283 106 C 277 113, 270 117, 263 117 L 258 106 C 262 96, 263 84, 261 72 C 259 58, 254 47, 246 40 Z"
+        d="M 270 86 L 283 84 C 290 88, 294 97, 294 109 C 293 124, 289 139, 283 152 C 278 161, 270 167, 260 169 L 245 158 L 245 146 L 252 132 L 258 117 L 260 101 L 260 90 Z"
       />
       <path
         id="brisket"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 91 97 L 136 105 L 140 121 L 139 139 L 124 147 C 113 145, 104 140, 97 132 C 93 121, 91 109, 91 97 Z"
+        d="M 92 98 L 136 105 L 141 121 L 140 136 L 131 145 L 118 149 L 106 146 L 98 138 L 94 126 L 92 113 Z"
       />
       <path
         id="plate"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 136 105 L 226 104 L 227 117 L 223 132 L 212 145 L 161 146 L 139 140 L 140 121 Z"
+        d="M 136 105 L 226 103 L 227 118 L 224 130 L 217 139 L 205 146 L 186 149 L 165 149 L 148 145 L 140 136 L 141 121 Z"
       />
       <path
         id="flank"
         class="cut-region"
         style="stroke-width:0.264583"
-        d="M 226 104 L 258 106 L 264 117 L 267 130 L 262 142 L 247 146 L 231 149 L 212 145 L 223 132 L 227 117 Z"
+        d="M 226 103 L 252 101 L 260 101 L 258 117 L 252 132 L 245 146 L 245 158 L 233 157 L 221 150 L 212 145 L 217 139 L 224 130 L 227 118 Z"
       />
     </g>
   </svg>
@@ -2696,6 +2702,15 @@
         description: "Rear loin group with moderate marbling and a robust beef-forward profile.",
         cookingMethods: ["Grilling", "Cast iron", "Roasting"],
         quickTip: "Do not overcook it. Sirloin is best when sliced properly and rested."
+      },
+      picanha: {
+        id: "picanha",
+        displayName: "Picanha",
+        regionId: "picanha",
+        location: "Top rear rump cap above the sirloin near the tail end.",
+        description: "Distinct rump-cap cut known for a thick fat cap and concentrated beef flavor.",
+        cookingMethods: ["Grill", "Reverse sear", "Roast", "Skewer over coals"],
+        quickTip: "Keep the fat cap on, score lightly, and render it slowly before the final sear."
       },
       round: {
         id: "round",


### PR DESCRIPTION
### Motivation
- Improve visible anatomy of the Beef Cuts Explorer by adding a distinct picanha region and making lower/rear regions visibly more contoured and differentiated. 
- Keep the existing cow silhouette, interaction model, and region IDs so hover/click/highlight and card sync remain unchanged. 

### Description
- Restored `picanha` as its own SVG region in the upper rear/rump area and added a corresponding `BEEF_CUTS.picanha` entry so it participates in the existing selection/highlight logic. (Picanha added: yes.)
- Reshaped these SVG region paths to produce a clearer map: `sirloin`, `picanha` (new), `round`, `brisket`, `plate`, and `flank` were updated to tighter, more contoured outlines to avoid flat block-like regions while keeping all paths inside the cow silhouette. 
- Preserved the base silhouette and existing IDs/class names (`.cut-region`, `regionId`), so existing hover/click/highlight/card sync wiring is preserved. 
- File(s) changed: `public/index.html` (SVG path updates and new `BEEF_CUTS.picanha` entry). 

### Testing
- Ran `node --check server.js` and it passed (no syntax errors). 
- Attempted `npm start` to exercise the runtime, but startup is blocked in this environment due to a missing `OPENAI_API_KEY` environment variable so full runtime validation could not complete. 
- No changes were made to interaction code paths; region IDs and mapping were preserved so hover/click/highlight and card sync should continue to work with the updated SVG shapes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76edccef0832fbc7ee99462bd90a5)