### PR TITLE
Fix hero banner clipping and light-mode visibility contrast

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -398,6 +398,33 @@
       margin-left: auto;
     }
 
+    body.light .first-run-hint,
+    body[data-theme="light"] .first-run-hint {
+      border-color: rgba(196, 107, 63, 0.40);
+      background: rgba(240, 143, 96, 0.14);
+      color: #5b2b12;
+    }
+
+    body.light .first-run-hint-cta,
+    body[data-theme="light"] .first-run-hint-cta {
+      border-color: rgba(184, 98, 58, 0.62);
+      background: rgba(230, 126, 77, 0.22);
+      color: #4b230e;
+    }
+
+    body.light .first-run-hint-cta:hover,
+    body[data-theme="light"] .first-run-hint-cta:hover {
+      border-color: rgba(168, 88, 52, 0.78);
+      background: rgba(222, 116, 66, 0.30);
+    }
+
+    body.light .first-run-hint-close,
+    body[data-theme="light"] .first-run-hint-close {
+      border-color: rgba(155, 167, 182, 0.75);
+      background: rgba(255, 255, 255, 0.75);
+      color: #2c3642;
+    }
+
     .floating-feedback-btn {
       position: fixed;
       right: 16px;
@@ -531,6 +558,13 @@
       color: #dff8ea;
       border-color: rgba(46, 204, 113, 0.35);
       background: rgba(46, 204, 113, 0.08);
+    }
+
+    body.light .meta-pill.live,
+    body[data-theme="light"] .meta-pill.live {
+      color: #124427;
+      border-color: rgba(38, 130, 78, 0.52);
+      background: rgba(46, 143, 84, 0.22);
     }
 
     .meta-pill.cached {
@@ -775,19 +809,14 @@
     }
 
     .hero-banner {
-      position: relative;
+      display: block;
       width: 100%;
-      min-height: 220px;
-      height: clamp(220px, 28vw, 280px);
-      border-radius: 24px;
-      border: 1px solid rgba(255, 149, 95, 0.22);
+      height: auto;
+      border-radius: 16px;
+      border: 0;
       margin: 6px 0 18px;
-      box-shadow: var(--shadow);
-      overflow: hidden;
-      background-image: url('/assets/banner-hero.png');
-      background-size: cover;
-      background-position: center;
-      background-repeat: no-repeat;
+      box-shadow: none;
+      overflow: visible;
     }
 
     .panel:hover,
@@ -1960,7 +1989,6 @@
       }
 
       .hero-banner {
-        min-height: 220px;
         height: auto;
       }
     }
@@ -2525,7 +2553,7 @@
       <button class="first-run-hint-close" id="closeFirstRunHint" type="button">Close</button>
     </div>
 <section class="zone zone-radar">
-  <div class="hero-banner app-enter app-enter-delay-2" aria-label="Smoke Radar hero banner image"></div>
+  <img class="hero-banner app-enter app-enter-delay-2" src="/assets/banner-hero.png" alt="Smoke Radar hero banner image" />
 
   <div class="panel smoke-hero app-enter app-enter-delay-2" id="smokeIndexCard">
   <div class="smoke-index-top">


### PR DESCRIPTION
### Motivation
- The hero banner image was visually clipped by decorative framing and container styles, and light-mode UI elements (Live pill/card and helper box) were too low-contrast and hard to read. 
- The intent is to restore a clean, full-width hero image and increase contrast for live and helper UI in light theme without changing layout or dark-mode styling.

### Description
- Replaced the background-styled hero `div` with a direct `<img>` element and removed the orange border, shadow, and overflow clipping so the banner renders as a clean full-width image block (`public/index.html`).
- Simplified `.hero-banner` CSS to remove the decorative frame, reset `border`/`box-shadow` and allow the image to display without cropping.
- Added light-mode overrides to strengthen `.meta-pill.live` with a darker green text and a more visible green background/border to improve readability on light backgrounds.
- Added light-mode overrides for the first-run helper box and its CTAs/close button to increase text and button contrast while retaining a soft visual style.

### Testing
- Ran `node --check server.js` to verify the server-side JS parses without syntax errors and it succeeded.
- No other automated unit or visual tests are present in the repo, so no further automated verification was run.

Validation: banner clipping/frame, light-mode live visibility, and light-mode helper visibility were all addressed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98fea5314832f9525b941f22613bf)