### PR TITLE
Upgrade `/public/app` to premium Smoke Radar mobile experience

### DIFF
--- a/public/app/app.css
+++ b/public/app/app.css
@@ -1,35 +1,26 @@
 :root {
   color-scheme: dark;
   --bg: #050506;
-  --bg-elevated: #111114;
-  --line: #2b2a30;
-  --text: #f7f5ef;
-  --muted: #b0a99b;
-  --accent: #ff5a1f;
-  --accent-soft: #ff9d59;
-  --chip: #1b1a1f;
-  --glow: 0 0 0 1px rgba(255, 118, 35, 0.4), 0 10px 24px rgba(255, 77, 0, 0.35);
+  --bg-elevated: #15161a;
+  --text: #f7f3ec;
+  --muted: #b3aa9c;
+  --line: rgba(255, 255, 255, 0.11);
+  --accent: #ff6b2c;
+  --accent-soft: #ffb07c;
 }
 
 * { box-sizing: border-box; }
 body {
   margin: 0;
+  min-height: 100vh;
   font-family: "Heebo", "Assistant", system-ui, sans-serif;
   background:
-    radial-gradient(circle at 20% 10%, rgba(255, 98, 25, 0.18) 0, transparent 35%),
-    radial-gradient(circle at 80% 18%, rgba(255, 58, 0, 0.18) 0, transparent 32%),
-    radial-gradient(circle at 50% 120%, rgba(255, 136, 46, 0.2) 0, transparent 45%),
-    linear-gradient(180deg, #0d0b0c 0%, var(--bg) 40%, #050506 100%);
-  background-image:
-    radial-gradient(circle at 20% 10%, rgba(255, 98, 25, 0.18) 0, transparent 35%),
-    radial-gradient(circle at 80% 18%, rgba(255, 58, 0, 0.18) 0, transparent 32%),
-    radial-gradient(circle at 50% 120%, rgba(255, 136, 46, 0.2) 0, transparent 45%),
-    linear-gradient(180deg, #0d0b0c 0%, var(--bg) 40%, #050506 100%),
-    url("/app/assets/app-bg-smoke.jpg"),
-    url("/app/assets/fire-texture.png");
-  background-size: cover, cover, cover, cover, cover, 1200px;
-  background-repeat: no-repeat;
-  background-blend-mode: screen, screen, normal, normal, overlay, soft-light;
+    radial-gradient(circle at 10% 8%, rgba(255, 115, 40, 0.22), transparent 35%),
+    radial-gradient(circle at 80% 20%, rgba(255, 69, 0, 0.15), transparent 30%),
+    linear-gradient(180deg, #050506 0%, #0a0b0f 45%, #090909 100%),
+    url('/app/assets/app-bg-smoke.jpg');
+  background-size: cover, cover, cover, cover;
+  background-position: center;
   color: var(--text);
 }
 
@@ -37,164 +28,136 @@ body {
   min-height: 100vh;
   max-width: 520px;
   margin: 0 auto;
-  padding: max(18px, env(safe-area-inset-top)) 16px calc(24px + env(safe-area-inset-bottom));
+  padding: max(16px, env(safe-area-inset-top)) 14px calc(18px + env(safe-area-inset-bottom));
   display: grid;
   grid-template-rows: auto 1fr auto;
-  gap: 16px;
-  position: relative;
-  isolation: isolate;
+  gap: 12px;
 }
 
-.app-shell::before {
-  content: "";
-  position: absolute;
-  inset: 0;
+.app-header {
+  border: 1px solid var(--line);
   border-radius: 24px;
-  background:
-    radial-gradient(circle at 18% 10%, rgba(255, 144, 84, 0.16), transparent 35%),
-    radial-gradient(circle at 82% 22%, rgba(255, 90, 31, 0.22), transparent 32%),
-    linear-gradient(180deg, rgba(8, 8, 10, 0.84), rgba(7, 7, 8, 0.92));
-  z-index: -1;
-  pointer-events: none;
-}
-
-.app-header h1 {
-  margin: 6px 0 0;
-  font-size: clamp(1.7rem, 5.4vw, 2.45rem);
-  line-height: 1.05;
-  letter-spacing: -0.02em;
-  text-wrap: balance;
-}
-.app-header { display: grid; gap: 4px; }
-.brand {
-  margin: 0;
-  color: var(--accent-soft);
-  font-weight: 800;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-}
-.hero-kicker {
-  margin: 0;
-  color: #f9b37f;
-  opacity: 0.86;
-  font-size: 0.78rem;
-  font-weight: 700;
-}
-.hero-subtitle {
-  margin: 2px 0 0;
-  font-size: .94rem;
-  color: var(--muted);
-}
-
-.app-shell:not([data-step="home"]) .hero-subtitle,
-.app-shell:not([data-step="home"]) .hero-kicker { display: none; }
-
-.screen-content { display: grid; gap: 12px; align-content: start; }
-
-.card {
-  background:
-    linear-gradient(160deg, rgba(255, 110, 35, 0.09), transparent 45%),
-    linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));
-  border: 1px solid var(--line);
-  border-radius: 20px;
   padding: 16px;
-  box-shadow: 0 8px 30px rgba(0,0,0,.34);
-}
-
-.btn {
-  border: 1px solid transparent;
-  border-radius: 16px;
-  padding: 16px;
-  font-size: 1.05rem;
-  font-weight: 800;
-  width: 100%;
-  cursor: pointer;
-  transition: transform .14s ease, box-shadow .2s ease, border-color .2s ease, background-color .2s ease;
-}
-.btn:active {
-  transform: translateY(1px) scale(.996);
-}
-.btn-primary {
-  background: linear-gradient(135deg, #ff7e36 0%, var(--accent) 45%, #e63b00 100%);
-  color: #fff;
-  box-shadow: var(--glow);
-}
-.btn-primary:hover {
-  box-shadow: 0 0 0 1px rgba(255, 126, 54, .55), 0 14px 26px rgba(255, 74, 13, .4);
-}
-.btn-ghost {
-  background: rgba(255,255,255,.02);
-  border-color: var(--line);
-  color: var(--text);
-}
-.btn-choice {
   background:
-    linear-gradient(155deg, rgba(255, 103, 25, 0.07), transparent 45%),
-    var(--bg-elevated);
-  border-color: var(--line);
-  color: var(--text);
-  text-align: right;
-  min-height: 68px;
-}
-.btn-choice.active {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(255,107,44,.25) inset, 0 8px 24px rgba(255, 90, 31, 0.2);
-}
-
-.app-nav { display: grid; grid-template-columns: 1fr 1.3fr; gap: 10px; }
-.list { margin: 8px 0 0; padding: 0 18px 0 0; display: grid; gap: 8px; }
-.chips { display: flex; flex-wrap: wrap; gap: 8px; }
-.chip { background: var(--chip); border: 1px solid var(--line); padding: 8px 10px; border-radius: 999px; font-size: .92rem; }
-.small { color: var(--muted); font-size: .9rem; }
-.hidden { display: none !important; }
-
-select, input {
-  width: 100%;
-  background: var(--bg-elevated);
-  color: var(--text);
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 12px;
-}
-
-label { font-size: .92rem; color: var(--muted); margin-bottom: 6px; display: block; }
-
-.app-shell[data-step="home"] .app-header {
-  background:
-    linear-gradient(180deg, rgba(0,0,0,.3), rgba(0,0,0,.55)),
-    url("/app/assets/hero-steak.jpg");
+    linear-gradient(180deg, rgba(10, 10, 12, 0.9), rgba(18, 12, 8, 0.82)),
+    url('/app/assets/hero-steak.jpg');
   background-size: cover;
   background-position: center;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45), inset 0 0 80px rgba(0,0,0,0.42);
+}
+.brand { margin: 0; color: var(--accent-soft); font-weight: 800; text-transform: uppercase; letter-spacing: .03em; }
+#screenTitle { margin: 8px 0 0; font-size: clamp(1.55rem, 5.2vw, 2.4rem); line-height: 1.05; font-weight: 900; }
+.hero-subtitle { margin: 6px 0 0; color: var(--muted); font-size: .92rem; }
+
+.progress-wrap { margin-top: 10px; display: grid; gap: 4px; }
+.progress-text { font-size: .78rem; color: #f5be93; }
+.progress-track { height: 6px; border-radius: 999px; background: rgba(255,255,255,.11); overflow: hidden; }
+.progress-fill { display: block; height: 100%; width: 0; background: linear-gradient(90deg, #ff9b61, #ff5a1f); transition: width .25s ease; }
+
+.screen-content {
+  border: 1px solid var(--line);
   border-radius: 24px;
-  padding: 18px 16px 20px;
-  border: 1px solid rgba(255, 146, 80, 0.26);
-  box-shadow: 0 14px 28px rgba(0, 0, 0, .45), 0 0 0 1px rgba(255, 115, 45, .28) inset;
-}
-.app-shell[data-step="home"] .brand {
-  font-size: .9rem;
-  color: #ffd2af;
-}
-.app-shell[data-step="home"] h1 {
-  font-size: clamp(2rem, 7vw, 2.8rem);
-  font-weight: 900;
-}
-.app-shell[data-step="home"] .screen-content {
-  background: rgba(14, 14, 17, .74);
-  border: 1px solid rgba(255, 138, 68, .16);
-  border-radius: 24px;
-  padding: 14px;
-  backdrop-filter: blur(2px);
-}
-.app-shell[data-step="home"] .btn-choice {
-  font-size: 1.08rem;
-  min-height: 74px;
+  padding: 12px;
+  background:
+    linear-gradient(160deg, rgba(255, 109, 50, 0.08), transparent 40%),
+    linear-gradient(180deg, rgba(21,22,26,.86), rgba(10,10,12,.94));
+  display: grid;
+  gap: 10px;
+  align-content: start;
+  overflow-y: auto;
 }
 
+.card {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: 12px;
+  background: linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,.02));
+}
+
+.visual-card {
+  position: relative;
+  min-height: 110px;
+  background:
+    linear-gradient(180deg, rgba(0,0,0,.2), rgba(0,0,0,.72)),
+    radial-gradient(circle at 80% 20%, rgba(255, 123, 62, 0.35), transparent 45%),
+    url('/app/assets/hot-trends.jpg');
+  background-size: cover;
+  background-position: center;
+}
+
+.visual-map {
+  min-height: 145px;
+  background:
+    linear-gradient(180deg, rgba(6,9,12,.16), rgba(8,8,8,.76)),
+    repeating-linear-gradient(45deg, rgba(255,111,52,.12), rgba(255,111,52,.12) 1px, transparent 1px, transparent 11px),
+    url('/app/assets/butcher-map.jpg');
+  background-size: cover;
+}
+
+.recipe-hero {
+  min-height: 180px;
+  display: grid;
+  align-content: end;
+  gap: 6px;
+  background:
+    linear-gradient(180deg, rgba(0,0,0,.2), rgba(0,0,0,.84)),
+    radial-gradient(circle at 85% 12%, rgba(255, 124, 66, 0.34), transparent 45%),
+    var(--recipe-image, url('/app/assets/recipe-steak.jpg'));
+  background-size: cover;
+  background-position: center;
+}
+
+.meta-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
+.meta-item { border: 1px solid var(--line); border-radius: 12px; padding: 8px; background: rgba(255,255,255,.02); }
+.meta-item strong { display: block; color: var(--accent-soft); font-size: .76rem; }
+
+.btn {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid transparent;
+  padding: 13px;
+  font-size: 1rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+.btn-primary {
+  color: white;
+  background: linear-gradient(135deg, #ff9b61 0%, #ff6b2c 50%, #df3f00 100%);
+  box-shadow: 0 0 0 1px rgba(255,121,56,.34), 0 12px 24px rgba(255,92,26,.36);
+}
+.btn-ghost { background: rgba(255,255,255,.03); color: var(--text); border-color: var(--line); }
+.btn-choice {
+  background: linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,.02));
+  border-color: var(--line);
+  color: var(--text);
+  text-align: start;
+}
+.btn-choice.active { border-color: rgba(255,117,49,.65); box-shadow: inset 0 0 0 1px rgba(255,117,49,.45); }
+
+.app-nav { display: grid; gap: 10px; grid-template-columns: 1fr 1.2fr; }
+.small { color: var(--muted); font-size: .88rem; margin: 0; }
+.list { margin: 8px 0 0; padding-inline: 18px; display: grid; gap: 7px; }
+.inline-actions { display: grid; gap: 8px; }
+.group-title { margin: 0 0 8px; color: var(--accent-soft); font-size: .87rem; }
+.check-item { display: flex; align-items: center; gap: 10px; padding: 7px 0; border-bottom: 1px dashed rgba(255,255,255,.09); }
+.chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.chip { padding: 6px 10px; border-radius: 999px; border: 1px solid var(--line); background: rgba(255,255,255,.03); font-size: .82rem; }
+.field { display: grid; gap: 5px; }
+label { color: var(--muted); font-size: .88rem; }
+select, input {
+  width: 100%;
+  background: #111317;
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  padding: 11px;
+}
+
+.hidden { display: none !important; }
+.fade-in { animation: fadeIn .28s ease; }
+
+@keyframes fadeIn { from { opacity: .15; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+
 @media (min-width: 700px) {
-  .app-shell {
-    margin-top: 18px;
-    border: 1px solid var(--line);
-    border-radius: 24px;
-    overflow: hidden;
-  }
+  .app-shell { margin-top: 16px; border: 1px solid var(--line); border-radius: 24px; overflow: hidden; }
 }

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,58 +1,154 @@
-const steps = ["home", "hot", "preferences", "cook", "recipe", "shopping", "butcher"];
+const STEPS = ["landing", "hot", "preferences", "cook", "recipe", "shopping", "butcher"];
 let currentStep = 0;
 
+const cutsCatalog = [
+  { id: "ribeye", labels: { he: "אנטריקוט", en: "Ribeye" }, aliases: ["ribeye", "אנטריקוט"] },
+  { id: "brisket", labels: { he: "בריסקט", en: "Brisket" }, aliases: ["brisket", "בריסקט"] },
+  { id: "asado", labels: { he: "אסאדו", en: "Asado" }, aliases: ["asado", "אסאדו"] },
+  { id: "picanha", labels: { he: "פיקניה", en: "Picanha" }, aliases: ["picanha", "פיקניה"] },
+  { id: "sirloin", labels: { he: "סינטה", en: "Sirloin" }, aliases: ["sirloin", "סינטה"] },
+  { id: "filet", labels: { he: "פילה", en: "Filet" }, aliases: ["filet", "fillet", "פילה"] },
+  { id: "short_ribs", labels: { he: "אסאדו / שפונדרה", en: "Short Ribs" }, aliases: ["short ribs", "שפונדרה"] },
+  { id: "chuck", labels: { he: "צוואר / כתף", en: "Chuck" }, aliases: ["chuck", "צוואר", "כתף"] },
+  { id: "flank", labels: { he: "פלנק", en: "Flank" }, aliases: ["flank", "פלנק"] },
+  { id: "striploin", labels: { he: "סינטה / סטריפלוין", en: "Striploin" }, aliases: ["striploin", "סטריפלוין"] },
+  { id: "tenderloin", labels: { he: "פילה מובחר", en: "Tenderloin" }, aliases: ["tenderloin"] }
+];
+
+const methods = [
+  { id: "grill", labels: { he: "גריל", en: "Grill" } },
+  { id: "cast_iron", labels: { he: "מחבת ברזל", en: "Cast Iron" } },
+  { id: "oven", labels: { he: "תנור", en: "Oven" } },
+  { id: "smoker", labels: { he: "מעשנה", en: "Smoker" } },
+  { id: "low_slow", labels: { he: "נמוך ואיטי", en: "Low & Slow" } },
+  { id: "pan_sear", labels: { he: "צריבה במחבת", en: "Pan Sear" } },
+  { id: "reverse_sear", labels: { he: "ריברס סיר", en: "Reverse Sear" } }
+];
+
+const flavorProfiles = [
+  { id: "classic", labels: { he: "קלאסי", en: "Classic" } },
+  { id: "smoky", labels: { he: "מעושן", en: "Smoky" } },
+  { id: "bold", labels: { he: "עז", en: "Bold" } },
+  { id: "mediterranean", labels: { he: "ים תיכוני", en: "Mediterranean" } },
+  { id: "spicy", labels: { he: "חריף", en: "Spicy" } }
+];
+
+const copy = {
+  he: {
+    dir: "rtl",
+    brand: "🔥 Smoke Radar",
+    landingTitle: "מה בא לך להכין היום?",
+    landingSubtitle: "האפליקציה שבוחרת עבורך מה חם, מה לבשל, ואיפה לקנות.",
+    hotAction: "🔥 מה חם עכשיו",
+    knowAction: "😋 אני יודע מה בא לי",
+    next: "המשך",
+    finish: "סיום",
+    back: "חזרה",
+    stepLabel: "שלב",
+    titles: {
+      landing: "מה בא לך להכין היום?",
+      hot: "מה חם עכשיו",
+      preferences: "מה לבשל",
+      cook: "איך לבשל",
+      recipe: "מתכון מלא",
+      shopping: "רשימת קניות",
+      butcher: "איפה לקנות"
+    }
+  },
+  en: {
+    dir: "ltr",
+    brand: "🔥 Smoke Radar",
+    landingTitle: "What do you want to cook today?",
+    landingSubtitle: "A premium flow from trends to recipe to butcher map.",
+    hotAction: "🔥 What’s Hot Now",
+    knowAction: "😋 I Know What I Want",
+    next: "Next",
+    finish: "Finish",
+    back: "Back",
+    stepLabel: "Step",
+    titles: {
+      landing: "What do you want to cook today?",
+      hot: "What’s Hot Now",
+      preferences: "What to cook",
+      cook: "How to cook",
+      recipe: "Cooking Guide",
+      shopping: "Shopping List",
+      butcher: "Where to buy"
+    }
+  }
+};
+
 const state = {
+  lang: document.documentElement.lang === "en" ? "en" : "he",
   homeChoice: null,
   hotList: [],
   selectedHot: null,
-  preferences: { meatType: "beef", cut: "Ribeye", method: "גריל", flavor: "Smoky", dietaryPreference: "kosher" },
+  preferences: {
+    meatType: "beef",
+    cutId: "ribeye",
+    methodId: "grill",
+    flavorId: "smoky",
+    dietaryPreference: "kosher",
+    servings: 4
+  },
   mealIdeas: [],
   selectedMealIdea: null,
   recipe: null,
-  shopping: [],
+  shopping: { meat: [], seasoning: [], sauceIngredients: [], sideIngredients: [], drinks: [] },
+  shoppingChecks: {},
   butchers: [],
   location: null
 };
 
-const titleMap = {
-  home: "מה בא לך להכין היום?",
-  hot: "מה חם עכשיו",
-  preferences: "בחר העדפות",
-  cook: "מה לבשל",
-  recipe: "איך לבשל",
-  shopping: "מה לקנות",
-  butcher: "איפה לקנות"
+const el = {
+  appRoot: document.getElementById("app"),
+  header: document.getElementById("appHeader"),
+  title: document.getElementById("screenTitle"),
+  subtitle: document.getElementById("screenSubtitle"),
+  content: document.getElementById("screenContent"),
+  nextBtn: document.getElementById("nextBtn"),
+  backBtn: document.getElementById("backBtn"),
+  progressFill: document.getElementById("progressFill"),
+  progressText: document.getElementById("progressText")
 };
 
-const screenTitle = document.getElementById("screenTitle");
-const screenContent = document.getElementById("screenContent");
-const backBtn = document.getElementById("backBtn");
-const nextBtn = document.getElementById("nextBtn");
-const appRoot = document.getElementById("app");
-
-backBtn.addEventListener("click", () => {
+el.backBtn.addEventListener("click", () => {
   if (currentStep > 0) {
     currentStep -= 1;
     render();
   }
 });
-nextBtn.addEventListener("click", async () => {
-  await handleNext();
-});
+el.nextBtn.addEventListener("click", handleNext);
 
-function setStep(stepIndex) {
-  currentStep = stepIndex;
-  render();
+function t(path) {
+  return path.split(".").reduce((acc, key) => acc?.[key], copy[state.lang]);
 }
 
-function render() {
-  const step = steps[currentStep];
-  appRoot.dataset.step = step;
-  screenTitle.textContent = titleMap[step];
-  backBtn.classList.toggle("hidden", currentStep === 0);
-  nextBtn.textContent = currentStep === steps.length - 1 ? "סיום" : "המשך";
+function getCutById(id) { return cutsCatalog.find((c) => c.id === id) || cutsCatalog[0]; }
+function getMethodById(id) { return methods.find((m) => m.id === id) || methods[0]; }
 
-  if (step === "home") return renderHome();
+function render() {
+  const step = STEPS[currentStep];
+  const totalFlowSteps = STEPS.length - 1;
+  const progress = step === "landing" ? 0 : Math.round((currentStep / totalFlowSteps) * 100);
+
+  document.documentElement.lang = state.lang;
+  document.documentElement.dir = t("dir");
+  el.appRoot.dataset.step = step;
+  el.title.textContent = t(`titles.${step}`);
+  el.subtitle.textContent = step === "landing" ? t("landingSubtitle") : "";
+  el.progressFill.style.width = `${progress}%`;
+  el.progressText.textContent = `${t("stepLabel")} ${Math.max(currentStep, 1)}/${totalFlowSteps}`;
+  el.backBtn.textContent = t("back");
+  el.nextBtn.textContent = currentStep === STEPS.length - 1 ? t("finish") : t("next");
+  el.backBtn.classList.toggle("hidden", currentStep === 0);
+  el.nextBtn.classList.toggle("hidden", step === "landing");
+
+  el.content.classList.remove("fade-in");
+  void el.content.offsetWidth;
+  el.content.classList.add("fade-in");
+
+  if (step === "landing") return renderLanding();
   if (step === "hot") return renderHotNow();
   if (step === "preferences") return renderPreferences();
   if (step === "cook") return renderCookIdeas();
@@ -61,21 +157,28 @@ function render() {
   if (step === "butcher") return renderButchers();
 }
 
-function renderHome() {
-  screenContent.innerHTML = `
-    <button class="btn btn-choice ${state.homeChoice === "hot" ? "active" : ""}" data-choice="hot">🔥 מה חם עכשיו</button>
-    <button class="btn btn-choice ${state.homeChoice === "feel" ? "active" : ""}" data-choice="feel">😋 אני יודע מה בא לי</button>
-    <p class="small">כל מסך כולל החלטה אחת, בצורה מהירה ונוחה למובייל.</p>
+function renderLanding() {
+  el.content.innerHTML = `
+    <div class="card recipe-hero" style="--recipe-image:url('/app/assets/hero-steak.jpg')">
+      <p class="small">${state.lang === "he" ? "Smoke Radar Premium" : "Smoke Radar Premium"}</p>
+      <h2>${t("landingTitle")}</h2>
+      <p class="small">${t("landingSubtitle")}</p>
+    </div>
+    <button class="btn btn-choice" data-choice="hot">${t("hotAction")}</button>
+    <button class="btn btn-choice" data-choice="feel">${t("knowAction")}</button>
+    <div class="chips">${cutsCatalog.slice(0, 6).map((cut) => `<span class="chip">${cut.labels[state.lang]}</span>`).join("")}</div>
   `;
-  screenContent.querySelectorAll("[data-choice]").forEach((btn) => {
+
+  el.content.querySelectorAll("[data-choice]").forEach((btn) => {
     btn.addEventListener("click", async () => {
       state.homeChoice = btn.dataset.choice;
       if (state.homeChoice === "hot") {
         await loadHotNow();
-        setStep(1);
+        currentStep = 1;
       } else {
-        setStep(2);
+        currentStep = 2;
       }
+      render();
     });
   });
 }
@@ -84,205 +187,337 @@ async function loadHotNow() {
   if (state.hotList.length) return;
   const res = await fetch("/api/smoke-radar");
   const data = await res.json();
-  state.hotList = (data.videos || []).slice(0, 6).map((v) => ({
-    title: v.title,
-    cut: inferCut(v.title),
-    heat: v.smokeScore > 75 ? "🔥🔥🔥" : v.smokeScore > 45 ? "🔥🔥" : "🔥"
-  }));
+  state.hotList = (data.videos || []).slice(0, 8).map((v) => {
+    const cutId = inferCutId(v.title || "");
+    return {
+      title: v.title,
+      cutId,
+      heat: v.smokeScore > 75 ? "🔥🔥🔥" : v.smokeScore > 45 ? "🔥🔥" : "🔥"
+    };
+  });
 }
 
-function inferCut(text = "") {
-  const t = text.toLowerCase();
-  if (t.includes("ribeye")) return "Ribeye";
-  if (t.includes("brisket")) return "Brisket";
-  if (t.includes("picanha")) return "Picanha";
-  if (t.includes("short rib")) return "Short Ribs";
-  return "Beef Cut";
+function inferCutId(text) {
+  const low = String(text).toLowerCase();
+  const found = cutsCatalog.find((cut) => cut.aliases.some((a) => low.includes(a.toLowerCase())));
+  return found?.id || "ribeye";
 }
 
 function renderHotNow() {
   if (!state.hotList.length) {
-    screenContent.innerHTML = `<div class="card">טוען מגמות...</div>`;
+    el.content.innerHTML = `<div class="card">${state.lang === "he" ? "טוען מגמות חמות..." : "Loading hot trends..."}</div>`;
     return;
   }
-  screenContent.innerHTML = state.hotList.map((item, idx) => `
-      <button class="btn btn-choice ${state.selectedHot === idx ? "active" : ""}" data-hot="${idx}">
-        <strong>${item.heat} ${item.cut}</strong><br>
-        <span class="small">${item.title}</span>
-      </button>
-    `).join("");
 
-  screenContent.querySelectorAll("[data-hot]").forEach((btn) => {
+  el.content.innerHTML = `
+    <div class="card visual-card">
+      <h3>${state.lang === "he" ? "טרנדים מעושנים מהקהילה" : "Smoky Community Trends"}</h3>
+      <p class="small">${state.lang === "he" ? "בחר טרנד כדי להתחיל את המתכון." : "Pick a trend to start your recipe."}</p>
+    </div>
+    ${state.hotList.map((item, idx) => {
+      const cut = getCutById(item.cutId);
+      return `<button class="btn btn-choice ${state.selectedHot === idx ? "active" : ""}" data-hot="${idx}">
+        <strong>${item.heat} ${cut.labels[state.lang]}</strong>
+        <p class="small">${item.title}</p>
+      </button>`;
+    }).join("")}
+  `;
+
+  el.content.querySelectorAll("[data-hot]").forEach((btn) => {
     btn.addEventListener("click", () => {
       state.selectedHot = Number(btn.dataset.hot);
-      state.preferences.cut = state.hotList[state.selectedHot].cut;
+      state.preferences.cutId = state.hotList[state.selectedHot].cutId;
       renderHotNow();
     });
   });
 }
 
 function renderPreferences() {
-  screenContent.innerHTML = `
+  el.content.innerHTML = `
     <div class="card">
-      <label>סוג בשר</label>
-      <select id="meatType"><option value="beef">Beef</option><option value="lamb">Lamb</option></select>
-      <label>נתח</label>
-      <input id="cut" value="${state.preferences.cut}" />
-      <label>שיטת בישול</label>
-      <select id="method"><option>גריל</option><option>מעשנה</option><option>תנור</option></select>
+      <div class="field"><label>${state.lang === "he" ? "סוג בשר" : "Meat type"}</label>
+        <select id="meatType">
+          <option value="beef">${state.lang === "he" ? "בקר" : "Beef"}</option>
+          <option value="lamb">${state.lang === "he" ? "טלה" : "Lamb"}</option>
+          <option value="veal">${state.lang === "he" ? "עגל" : "Veal"}</option>
+        </select>
+      </div>
+      <div class="field"><label>${state.lang === "he" ? "נתח" : "Cut"}</label>
+        <select id="cutId">${cutsCatalog.map((cut) => `<option value="${cut.id}">${cut.labels[state.lang]}</option>`).join("")}</select>
+      </div>
+      <div class="field"><label>${state.lang === "he" ? "שיטת בישול" : "Cooking method"}</label>
+        <select id="methodId">${methods.map((m) => `<option value="${m.id}">${m.labels[state.lang]}</option>`).join("")}</select>
+      </div>
+      <div class="field"><label>${state.lang === "he" ? "פרופיל טעמים" : "Flavor profile"}</label>
+        <select id="flavorId">${flavorProfiles.map((f) => `<option value="${f.id}">${f.labels[state.lang]}</option>`).join("")}</select>
+      </div>
+      <div class="field"><label>${state.lang === "he" ? "כשרות" : "Kosher preference"}</label>
+        <select id="dietaryPreference">
+          <option value="kosher">${state.lang === "he" ? "כשר" : "Kosher"}</option>
+          <option value="non-kosher">${state.lang === "he" ? "לא כשר" : "Non-kosher"}</option>
+        </select>
+      </div>
+      <div class="field"><label>${state.lang === "he" ? "מספר מנות" : "Servings"}</label><input type="number" min="1" max="20" id="servings" value="${state.preferences.servings}" /></div>
     </div>
   `;
-  ["meatType", "cut", "method"].forEach((id) => {
-    document.getElementById(id).addEventListener("change", collectPreferences);
-    document.getElementById(id).addEventListener("input", collectPreferences);
+
+  ["meatType", "cutId", "methodId", "flavorId", "dietaryPreference", "servings"].forEach((id) => {
+    const input = document.getElementById(id);
+    input.value = state.preferences[id];
+    input.addEventListener("change", collectPreferences);
+    input.addEventListener("input", collectPreferences);
   });
 }
 
 function collectPreferences() {
   state.preferences.meatType = document.getElementById("meatType").value;
-  state.preferences.cut = document.getElementById("cut").value;
-  state.preferences.method = document.getElementById("method").value;
+  state.preferences.cutId = document.getElementById("cutId").value;
+  state.preferences.methodId = document.getElementById("methodId").value;
+  state.preferences.flavorId = document.getElementById("flavorId").value;
+  state.preferences.dietaryPreference = document.getElementById("dietaryPreference").value;
+  state.preferences.servings = Number(document.getElementById("servings").value || 1);
+}
+
+function buildIdeas() {
+  const cut = getCutById(state.preferences.cutId).labels[state.lang];
+  return [
+    { title: `${cut} ${state.lang === "he" ? "עם צריבה חזקה" : "with high-heat crust"}`, note: state.lang === "he" ? "ביצוע מהיר ומדויק" : "Quick precision cook", flavorId: "classic" },
+    { title: `${cut} ${state.lang === "he" ? "במעשנה ארוכה" : "smoked low and slow"}`, note: state.lang === "he" ? "עומק טעמים" : "Deep smoke profile", flavorId: "smoky" },
+    { title: `${cut} ${state.lang === "he" ? "עם רוטב פלפל" : "with pepper sauce"}`, note: state.lang === "he" ? "מנה עשירה" : "Bold steakhouse style", flavorId: "bold" },
+    { title: `${cut} ${state.lang === "he" ? "בסגנון ים תיכוני" : "Mediterranean style"}`, note: state.lang === "he" ? "עשבי תיבול והדר" : "Herbs and citrus", flavorId: "mediterranean" }
+  ];
 }
 
 function renderCookIdeas() {
-  if (!state.mealIdeas.length) {
-    state.mealIdeas = buildIdeas();
-  }
-  screenContent.innerHTML = state.mealIdeas.map((idea, idx) => `
-    <button class="btn btn-choice ${state.selectedMealIdea === idx ? "active" : ""}" data-idea="${idx}">
-      <strong>${idea.title}</strong>
-      <span class="small">${idea.note}</span>
-    </button>
-  `).join("");
+  state.mealIdeas = buildIdeas();
+  el.content.innerHTML = `
+    ${state.mealIdeas.map((idea, idx) => `
+      <button class="btn btn-choice ${state.selectedMealIdea === idx ? "active" : ""}" data-idea="${idx}">
+        <strong>${idea.title}</strong>
+        <p class="small">${idea.note}</p>
+      </button>`).join("")}
+  `;
 
-  screenContent.querySelectorAll("[data-idea]").forEach((btn) => {
+  el.content.querySelectorAll("[data-idea]").forEach((btn) => {
     btn.addEventListener("click", () => {
       state.selectedMealIdea = Number(btn.dataset.idea);
-      state.preferences.flavor = state.mealIdeas[state.selectedMealIdea].flavor;
+      state.preferences.flavorId = state.mealIdeas[state.selectedMealIdea].flavorId;
       renderCookIdeas();
     });
   });
 }
 
-function buildIdeas() {
-  const cut = state.preferences.cut || "Beef Cut";
-  return [
-    { title: `${cut} על גריל עם צריבה מהירה`, note: "עשיר וקלאסי", flavor: "Classic" },
-    { title: `${cut} בעישון איטי`, note: "טעם עמוק", flavor: "Smoky" },
-    { title: `${cut} בתנור עם רוטב פלפל`, note: "ארוחה אלגנטית", flavor: "Bold" },
-    { title: `${cut} בסגנון ים-תיכוני`, note: "רענן ומתובל", flavor: "Mediterranean" }
-  ].slice(0, 4);
-}
-
 async function loadRecipe() {
   const p = state.preferences;
+  const cut = getCutById(p.cutId).labels.en;
+  const method = getMethodById(p.methodId).labels.he;
+  const flavor = flavorProfiles.find((f) => f.id === p.flavorId)?.labels.en || "Smoky";
   const query = new URLSearchParams({
-    lang: "he",
+    lang: state.lang,
     meatType: p.meatType,
-    cut: p.cut,
-    method: p.method,
-    flavor: p.flavor,
+    cut,
+    method,
+    flavor,
     dietaryPreference: p.dietaryPreference,
+    servings: String(p.servings),
     mode: "all",
     r: String(Math.floor(Math.random() * 1000000))
   });
+
   const res = await fetch(`/api/ai-recipe?${query.toString()}`);
   const data = await res.json();
   state.recipe = data.structuredRecipe || null;
   state.shopping = buildShoppingList(state.recipe);
 }
 
+function recipeHeroForCut() {
+  const cutId = state.preferences.cutId;
+  if (cutId === "brisket") return "url('/app/assets/recipe-brisket.jpg')";
+  if (cutId === "picanha") return "url('/app/assets/recipe-picanha.jpg')";
+  return "url('/app/assets/recipe-steak.jpg')";
+}
+
 function renderRecipe() {
   if (!state.recipe) {
-    screenContent.innerHTML = `<div class="card">מכין מתכון חכם...</div>`;
+    el.content.innerHTML = `<div class="card">${state.lang === "he" ? "בונה מדריך בישול מלא..." : "Building your complete cooking guide..."}</div>`;
     loadRecipe().then(renderRecipe).catch(() => {
-      screenContent.innerHTML = `<div class="card">לא ניתן לטעון מתכון כרגע.</div>`;
+      el.content.innerHTML = `<div class="card">${state.lang === "he" ? "לא הצלחנו לטעון מתכון כרגע." : "Could not load recipe right now."}</div>`;
     });
     return;
   }
-  const main = state.recipe.main || {};
-  const sauces = (state.recipe.sauces || []).slice(0, 2).map((s) => s.name).join(" • ");
-  const sides = (state.recipe.sides || []).slice(0, 3).map((s) => s.name).join(" • ");
-  const drinks = (state.recipe.drinkPairings || []).slice(0, 2).map((d) => d.name).join(" • ");
 
-  screenContent.innerHTML = `
-    <div class="card"><strong>${main.title || "מנה מומלצת"}</strong><p class="small">${main.description || ""}</p></div>
-    <div class="card"><strong>מרכיבים</strong><ul class="list">${(main.ingredients || []).slice(0, 8).map((i) => `<li>${i}</li>`).join("")}</ul></div>
-    <div class="card"><strong>שלבי הכנה</strong><ol class="list">${(main.steps || []).slice(0, 6).map((s) => `<li>${s}</li>`).join("")}</ol></div>
-    <div class="card"><strong>רטבים</strong><p>${sauces || "לפי המתכון"}</p></div>
-    <div class="card"><strong>תוספות</strong><p>${sides || "לפי המתכון"}</p></div>
-    <div class="card"><strong>שתייה מתאימה</strong><p>${drinks || "לפי המתכון"}</p></div>
-    <div class="card"><strong>כשרות</strong><p>${state.recipe.dietaryPreference === "kosher" ? "כשר" : "לא כשר"}</p></div>
+  const r = state.recipe;
+  const main = r.main || {};
+  const prep = main.prepTime || (state.lang === "he" ? "20 דקות" : "20 min");
+  const cook = main.cookTime || (state.lang === "he" ? "45 דקות" : "45 min");
+  const total = main.totalTime || (state.lang === "he" ? "65 דקות" : "65 min");
+  const difficulty = main.difficulty || (state.lang === "he" ? "בינוני" : "Medium");
+
+  el.content.innerHTML = `
+    <div class="card recipe-hero" style="--recipe-image:${recipeHeroForCut()}">
+      <h2>${main.title || (state.lang === "he" ? "מתכון פרימיום" : "Premium Recipe")}</h2>
+      <p class="small">${main.description || ""}</p>
+    </div>
+
+    <div class="card meta-grid">
+      <div class="meta-item"><strong>${state.lang === "he" ? "זמן הכנה" : "Prep Time"}</strong>${prep}</div>
+      <div class="meta-item"><strong>${state.lang === "he" ? "זמן בישול" : "Cook Time"}</strong>${cook}</div>
+      <div class="meta-item"><strong>${state.lang === "he" ? "סה״כ זמן" : "Total Time"}</strong>${total}</div>
+      <div class="meta-item"><strong>${state.lang === "he" ? "קושי" : "Difficulty"}</strong>${difficulty}</div>
+      <div class="meta-item"><strong>${state.lang === "he" ? "מנות" : "Servings"}</strong>${state.preferences.servings}</div>
+      <div class="meta-item"><strong>${state.lang === "he" ? "כשרות" : "Kosher"}</strong>${state.preferences.dietaryPreference === "kosher" ? (state.lang === "he" ? "כשר" : "Kosher") : (state.lang === "he" ? "לא כשר" : "Non-kosher")}</div>
+    </div>
+
+    <div class="card"><h3>${state.lang === "he" ? "מרכיבים" : "Ingredients"}</h3><ul class="list">${(main.ingredients || []).map((i) => `<li>${i}</li>`).join("")}</ul></div>
+    <div class="card"><h3>${state.lang === "he" ? "שלבי הכנה" : "Step-by-step"}</h3><ol class="list">${(main.steps || []).map((s) => `<li>${s}</li>`).join("")}</ol></div>
+    <div class="card"><h3>${state.lang === "he" ? "רטבים" : "Sauces"}</h3><ul class="list">${(r.sauces || []).map((s) => `<li>${s.name}</li>`).join("")}</ul></div>
+    <div class="card"><h3>${state.lang === "he" ? "תוספות" : "Side Dishes"}</h3><ul class="list">${(r.sides || []).map((s) => `<li>${s.name}</li>`).join("")}</ul></div>
+    <div class="card"><h3>${state.lang === "he" ? "שתייה מתאימה" : "Drink Pairings"}</h3><ul class="list">${(r.drinkPairings || []).map((d) => `<li>${d.name}</li>`).join("")}</ul></div>
+
+    <div class="inline-actions">
+      <button class="btn btn-ghost" id="regenBtn">${state.lang === "he" ? "צור מתכון מחדש" : "Regenerate Recipe"}</button>
+      <button class="btn btn-ghost" id="servingBtn">${state.lang === "he" ? "שנה מספר מנות" : "Change Servings"}</button>
+      <button class="btn btn-primary" id="toShoppingBtn">${state.lang === "he" ? "המשך לרשימת קניות" : "Continue to Shopping List"}</button>
+    </div>
   `;
+
+  document.getElementById("regenBtn").addEventListener("click", async () => {
+    state.recipe = null;
+    renderRecipe();
+  });
+  document.getElementById("servingBtn").addEventListener("click", () => {
+    const v = window.prompt(state.lang === "he" ? "כמה מנות?" : "How many servings?", String(state.preferences.servings));
+    const servings = Number(v);
+    if (Number.isFinite(servings) && servings > 0 && servings <= 20) {
+      state.preferences.servings = servings;
+      state.recipe = null;
+      renderRecipe();
+    }
+  });
+  document.getElementById("toShoppingBtn").addEventListener("click", () => {
+    currentStep = 5;
+    render();
+  });
 }
 
 function buildShoppingList(recipe) {
-  if (!recipe?.main) return [];
-  const items = [
-    ...recipe.main.ingredients || [],
-    ...(recipe.sauces || []).flatMap((s) => s.ingredients || []),
-    ...(recipe.sides || []).map((s) => s.name),
-    ...(recipe.drinkPairings || []).map((d) => d.name)
-  ];
-  return [...new Set(items)].slice(0, 24);
+  const mainIng = recipe?.main?.ingredients || [];
+  const sauces = (recipe?.sauces || []).flatMap((s) => s.ingredients || [s.name]).filter(Boolean);
+  const sides = (recipe?.sides || []).flatMap((s) => s.ingredients || [s.name]).filter(Boolean);
+  const drinks = (recipe?.drinkPairings || []).map((d) => d.name).filter(Boolean);
+
+  return {
+    meat: mainIng.filter((i) => /beef|meat|rib|steak|brisket|פיקניה|בשר|נתח|אנטריקוט|פילה/i.test(i)),
+    seasoning: mainIng.filter((i) => /salt|pepper|paprika|garlic|spice|מלח|פלפל|תבלין|שום/i.test(i)),
+    sauceIngredients: [...new Set(sauces)],
+    sideIngredients: [...new Set(sides)],
+    drinks: [...new Set(drinks)]
+  };
 }
 
 function renderShopping() {
-  screenContent.innerHTML = `
-    <div class="card">
-      <strong>רשימת קניות</strong>
-      <ul class="list">${state.shopping.map((item) => `<li>${item}</li>`).join("")}</ul>
-    </div>
+  const groups = [
+    { key: "meat", he: "בשר", en: "Meat" },
+    { key: "seasoning", he: "תיבול", en: "Seasoning" },
+    { key: "sauceIngredients", he: "מרכיבי רוטב", en: "Sauce ingredients" },
+    { key: "sideIngredients", he: "מרכיבי תוספות", en: "Side dish ingredients" },
+    { key: "drinks", he: "שתייה", en: "Drinks" }
+  ];
+
+  el.content.innerHTML = `
+    ${groups.map((group) => {
+      const items = state.shopping[group.key] || [];
+      return `
+        <div class="card">
+          <h3 class="group-title">${group[state.lang]}</h3>
+          ${items.length ? items.map((item, idx) => {
+            const id = `${group.key}-${idx}`;
+            return `<label class="check-item"><input type="checkbox" data-check="${id}" ${state.shoppingChecks[id] ? "checked" : ""} /> <span>${item}</span></label>`;
+          }).join("") : `<p class="small">${state.lang === "he" ? "לא נוספו פריטים" : "No items added"}</p>`}
+        </div>`;
+    }).join("")}
+
+    <button class="btn btn-ghost" id="copyList">${state.lang === "he" ? "העתק רשימה" : "Copy list"}</button>
+    <button class="btn btn-primary" id="toButchers">${state.lang === "he" ? "המשך לאיתור קצביות" : "Continue to butcher finder"}</button>
   `;
+
+  el.content.querySelectorAll("[data-check]").forEach((checkbox) => {
+    checkbox.addEventListener("change", () => {
+      state.shoppingChecks[checkbox.dataset.check] = checkbox.checked;
+    });
+  });
+
+  document.getElementById("copyList").addEventListener("click", async () => {
+    const list = Object.values(state.shopping).flat().join("\n");
+    try {
+      await navigator.clipboard.writeText(list);
+      alert(state.lang === "he" ? "הרשימה הועתקה" : "List copied");
+    } catch {
+      alert(state.lang === "he" ? "לא הצלחנו להעתיק" : "Copy failed");
+    }
+  });
+  document.getElementById("toButchers").addEventListener("click", () => {
+    currentStep = 6;
+    render();
+  });
 }
 
 async function loadButchers() {
   if (!navigator.geolocation) throw new Error("Location unavailable");
-  const position = await new Promise((resolve, reject) => navigator.geolocation.getCurrentPosition(resolve, reject, { timeout: 12000 }));
-  const lat = position.coords.latitude;
-  const lng = position.coords.longitude;
-  state.location = { lat, lng };
-  const res = await fetch(`/api/butchers-nearby?lat=${encodeURIComponent(lat)}&lng=${encodeURIComponent(lng)}`);
+  const pos = await new Promise((resolve, reject) => navigator.geolocation.getCurrentPosition(resolve, reject, { timeout: 12000 }));
+  state.location = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+  const res = await fetch(`/api/butchers-nearby?lat=${encodeURIComponent(state.location.lat)}&lng=${encodeURIComponent(state.location.lng)}`);
   state.butchers = await res.json();
 }
 
 function renderButchers() {
   if (!state.butchers.length && !state.location) {
-    screenContent.innerHTML = `<button id="findButchers" class="btn btn-primary">מצא קצביות קרובות</button>`;
+    el.content.innerHTML = `
+      <div class="card visual-map">
+        <h3>${state.lang === "he" ? "איתור קצביה קרובה" : "Find nearby butcher"}</h3>
+        <p class="small">${state.lang === "he" ? "ויזואל מפה עם נקודות חמות סביבך." : "Map-like discovery with orange location pins."}</p>
+      </div>
+      <button id="findButchers" class="btn btn-primary">${state.lang === "he" ? "📍 מצא קצביות קרובות" : "📍 Find nearby butcher shops"}</button>
+    `;
     document.getElementById("findButchers").addEventListener("click", async () => {
-      screenContent.innerHTML = `<div class="card">מחפש קצביות בסביבה...</div>`;
+      el.content.innerHTML = `<div class="card">${state.lang === "he" ? "מאתר מיקום וקצביות..." : "Fetching your location and butcher shops..."}</div>`;
       try {
         await loadButchers();
         renderButchers();
       } catch {
-        screenContent.innerHTML = `<div class="card">לא הצלחנו למשוך מיקום. אפשר לאשר הרשאת מיקום ולנסות שוב.</div>`;
+        el.content.innerHTML = `<div class="card">${state.lang === "he" ? "נדרשת הרשאת מיקום כדי לאתר קצביות." : "Location permission is required to find butcher shops."}</div>`;
       }
     });
     return;
   }
 
-  screenContent.innerHTML = state.butchers.slice(0, 8).map((b) => `
-    <div class="card">
-      <strong>${b.name}</strong>
-      <p class="small">${b.address || ""}</p>
-      <p class="small">⭐ ${b.rating || "-"} (${b.userRatingsTotal || 0})</p>
-      <a class="btn btn-primary" href="${b.mapsUrl}" target="_blank" rel="noopener">פתח ב-Google Maps</a>
-    </div>
-  `).join("");
+  el.content.innerHTML = `
+    <div class="card visual-map"><h3>${state.lang === "he" ? "קצביות מומלצות באזור שלך" : "Top butcher shops near you"}</h3></div>
+    ${state.butchers.slice(0, 8).map((b) => {
+      const stars = "⭐".repeat(Math.max(1, Math.min(5, Math.round(b.rating || 4))));
+      return `
+        <article class="card">
+          <strong>📍 ${b.name}</strong>
+          <p class="small">${b.address || ""}</p>
+          <p class="small">${stars} ${b.rating || "-"} (${b.userRatingsTotal || 0})</p>
+          <a class="btn btn-primary" href="${b.mapsUrl}" target="_blank" rel="noopener">${state.lang === "he" ? "פתח במפות" : "Open in Maps"}</a>
+        </article>`;
+    }).join("")}
+  `;
 }
 
 async function handleNext() {
-  const step = steps[currentStep];
-
-  if (step === "home" && !state.homeChoice) return;
+  const step = STEPS[currentStep];
   if (step === "hot" && state.homeChoice === "hot" && state.selectedHot === null) return;
   if (step === "cook" && state.selectedMealIdea === null) return;
 
-  if (currentStep < steps.length - 1) {
+  if (currentStep < STEPS.length - 1) {
     currentStep += 1;
     render();
   } else {
-    setStep(0);
+    currentStep = 0;
+    state.recipe = null;
+    render();
   }
 }
 

--- a/public/app/assets/README.md
+++ b/public/app/assets/README.md
@@ -1,0 +1,14 @@
+# Smoke Radar App Visual Assets
+
+The app supports optional campaign-style image assets in this folder.
+
+Recommended files:
+- `app-bg-smoke.jpg`
+- `hero-steak.jpg`
+- `hot-trends.jpg`
+- `butcher-map.jpg`
+- `recipe-brisket.jpg`
+- `recipe-steak.jpg`
+- `recipe-picanha.jpg`
+
+If these files are not present, the app still renders with layered dark gradients, smoke-like overlays, and ember highlights.

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -9,19 +9,24 @@
   <link rel="stylesheet" href="/app/app.css" />
 </head>
 <body>
-  <main id="app" class="app-shell">
-    <header class="app-header">
+  <main id="app" class="app-shell" data-step="landing">
+    <header id="appHeader" class="app-header">
       <p class="brand">🔥 Smoke Radar</p>
-      <p class="hero-kicker">Premium Fire Edition</p>
-      <h1 id="screenTitle">מה בא לך להכין היום?</h1>
-      <p class="hero-subtitle">בוחרים בשר, מציתים טעם, ומבשלים כמו קמפיין.</p>
+      <h1 id="screenTitle"></h1>
+      <p id="screenSubtitle" class="hero-subtitle"></p>
+      <div class="progress-wrap" aria-hidden="true">
+        <span id="progressText" class="progress-text"></span>
+        <div class="progress-track">
+          <span id="progressFill" class="progress-fill"></span>
+        </div>
+      </div>
     </header>
 
     <section id="screenContent" class="screen-content"></section>
 
     <nav class="app-nav">
-      <button id="backBtn" class="btn btn-ghost" type="button">חזרה</button>
-      <button id="nextBtn" class="btn btn-primary" type="button">המשך</button>
+      <button id="backBtn" class="btn btn-ghost" type="button"></button>
+      <button id="nextBtn" class="btn btn-primary" type="button"></button>
     </nav>
   </main>
 


### PR DESCRIPTION
### Motivation
- Improve the isolated mobile experience under `public/app/` to match campaign mockups with a bold landing screen, smoky/fire visual language, orange accents and stronger mobile-first flows.
- Keep the existing app flow and backend endpoints intact while making the UI feel like a real premium product and not touching the main dashboard at `/`.

### Description
- Added a dedicated landing/progress header and stronger step flow and transitions in `public/app/index.html` and `public/app/app.js` (landing → hot → preferences → cook → recipe → shopping → butcher) with localized copy for Hebrew/English and stable internal cut IDs.
- Rebuilt the visual language in `public/app/app.css` to a dark smoky/fire style with image-backed cards, recipe hero, map-style butcher header, orange accents and graceful CSS fallbacks when campaign images are absent.
- Expanded data/options in `public/app/app.js` including a full `cutsCatalog`, cooking `methods`, `flavorProfiles`, servings and kosher options, improved recipe rendering (times, difficulty, servings, kosher, ingredients, steps, sauces, sides, drinks), shopping list grouping with checkboxes and copy action, and a map-feel butcher finder using the existing `/api/butchers-nearby` endpoint.
- Added `public/app/assets/README.md` documenting optional image slots (`app-bg-smoke.jpg`, `hero-steak.jpg`, `hot-trends.jpg`, `butcher-map.jpg`, `recipe-brisket.jpg`, `recipe-steak.jpg`, `recipe-picanha.jpg`) and confirming the UI remains stable without them; files changed: `public/app/index.html`, `public/app/app.css`, `public/app/app.js`, `public/app/assets/README.md`.

### Testing
- `node --check public/app/app.js` was executed and succeeded with no syntax errors in the JavaScript bundle.
- `node --check public/app/app.css` was attempted and failed because Node does not accept `.css` as a JavaScript module (this is an expected tooling limitation and not a runtime CSS failure). 
- Verified changed files are limited to the app folder by listing committed paths; the main dashboard at `/` was not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc3cca794832fa062eda2f771e18e)