### PR TITLE
Polish Smoke Radar mobile app: opening splash, recipe upgrades, and butcher finder polish

### DIFF
--- a/public/app/app.css
+++ b/public/app/app.css
@@ -24,6 +24,33 @@ body {
   color: var(--text);
 }
 
+.opening-splash {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(circle at 52% 46%, rgba(255, 132, 73, 0.24), transparent 42%),
+    radial-gradient(circle at 40% 38%, rgba(255, 89, 0, 0.24), transparent 36%),
+    repeating-radial-gradient(circle at center, rgba(255, 125, 66, 0.11) 0 1px, transparent 1px 11px),
+    linear-gradient(180deg, #050506 0%, #0d0e12 100%);
+  transition: opacity .35s ease, visibility .35s ease;
+}
+
+.opening-logo {
+  font-size: clamp(1.8rem, 9vw, 2.6rem);
+  font-weight: 900;
+  color: #ffd3b7;
+  text-shadow: 0 0 8px rgba(255, 128, 64, .48), 0 0 28px rgba(255, 81, 0, .5);
+  animation: splashPulse .95s ease-out;
+}
+
+.opening-splash.is-hidden {
+  opacity: 0;
+  visibility: hidden;
+}
+
 .app-shell {
   min-height: 100vh;
   max-width: 520px;
@@ -72,6 +99,7 @@ body {
   border-radius: 18px;
   padding: 12px;
   background: linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,.02));
+  transition: transform .22s ease, box-shadow .22s ease, border-color .22s ease;
 }
 
 .visual-card {
@@ -80,7 +108,7 @@ body {
   background:
     linear-gradient(180deg, rgba(0,0,0,.2), rgba(0,0,0,.72)),
     radial-gradient(circle at 80% 20%, rgba(255, 123, 62, 0.35), transparent 45%),
-    url('/app/assets/hot-trends.jpg');
+    url('/app/assets/hot-trends-bg.jpg');
   background-size: cover;
   background-position: center;
 }
@@ -88,10 +116,14 @@ body {
 .visual-map {
   min-height: 145px;
   background:
-    linear-gradient(180deg, rgba(6,9,12,.16), rgba(8,8,8,.76)),
-    repeating-linear-gradient(45deg, rgba(255,111,52,.12), rgba(255,111,52,.12) 1px, transparent 1px, transparent 11px),
-    url('/app/assets/butcher-map.jpg');
+    radial-gradient(circle at 18% 68%, rgba(255,111,52,.34) 0 6px, transparent 8px),
+    radial-gradient(circle at 58% 32%, rgba(255,111,52,.32) 0 5px, transparent 7px),
+    radial-gradient(circle at 80% 52%, rgba(255,111,52,.32) 0 5px, transparent 7px),
+    repeating-linear-gradient(25deg, rgba(255,255,255,.06), rgba(255,255,255,.06) 1px, transparent 1px, transparent 13px),
+    linear-gradient(180deg, rgba(6,9,12,.28), rgba(8,8,8,.86)),
+    url('/app/assets/butcher-map-bg.jpg');
   background-size: cover;
+  background-position: center;
 }
 
 .recipe-hero {
@@ -102,10 +134,21 @@ body {
   background:
     linear-gradient(180deg, rgba(0,0,0,.2), rgba(0,0,0,.84)),
     radial-gradient(circle at 85% 12%, rgba(255, 124, 66, 0.34), transparent 45%),
-    var(--recipe-image, url('/app/assets/recipe-steak.jpg'));
+    var(--recipe-image, url('/app/assets/recipe-card-bg.jpg'));
   background-size: cover;
   background-position: center;
 }
+
+.badges-row { display: flex; flex-wrap: wrap; gap: 8px; }
+.badge {
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 162, 120, 0.38);
+  border-radius: 999px;
+  font-size: .78rem;
+  background: rgba(255, 255, 255, .04);
+}
+.badge strong { color: var(--accent-soft); }
+.badge-emphasis { background: rgba(255, 107, 44, .2); border-color: rgba(255, 107, 44, .66); }
 
 .meta-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
 .meta-item { border: 1px solid var(--line); border-radius: 12px; padding: 8px; background: rgba(255,255,255,.02); }
@@ -119,11 +162,13 @@ body {
   font-size: 1rem;
   font-weight: 800;
   cursor: pointer;
+  transition: transform .12s ease, box-shadow .18s ease, filter .18s ease;
 }
 .btn-primary {
   color: white;
   background: linear-gradient(135deg, #ff9b61 0%, #ff6b2c 50%, #df3f00 100%);
   box-shadow: 0 0 0 1px rgba(255,121,56,.34), 0 12px 24px rgba(255,92,26,.36);
+  animation: ctaGlow 2.6s ease-in-out infinite;
 }
 .btn-ghost { background: rgba(255,255,255,.03); color: var(--text); border-color: var(--line); }
 .btn-choice {
@@ -133,6 +178,12 @@ body {
   text-align: start;
 }
 .btn-choice.active { border-color: rgba(255,117,49,.65); box-shadow: inset 0 0 0 1px rgba(255,117,49,.45); }
+.btn:active { transform: translateY(1px) scale(.99); filter: brightness(.98); }
+.btn:hover { transform: translateY(-1px); }
+.card:hover { transform: translateY(-1px); border-color: rgba(255, 141, 89, .3); }
+.butcher-card.featured { border-color: rgba(255, 139, 81, .55); box-shadow: inset 0 0 0 1px rgba(255, 139, 81, .2); }
+
+.screen-transition { animation: stepShift .24s ease; }
 
 .app-nav { display: grid; gap: 10px; grid-template-columns: 1fr 1.2fr; }
 .small { color: var(--muted); font-size: .88rem; margin: 0; }
@@ -157,6 +208,18 @@ select, input {
 .fade-in { animation: fadeIn .28s ease; }
 
 @keyframes fadeIn { from { opacity: .15; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes splashPulse {
+  from { opacity: .4; transform: scale(.96); filter: blur(.4px); }
+  to { opacity: 1; transform: scale(1); filter: blur(0); }
+}
+@keyframes stepShift {
+  from { opacity: .75; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes ctaGlow {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(255,121,56,.34), 0 12px 24px rgba(255,92,26,.26); }
+  50% { box-shadow: 0 0 0 1px rgba(255,121,56,.5), 0 14px 30px rgba(255,92,26,.42); }
+}
 
 @media (min-width: 700px) {
   .app-shell { margin-top: 16px; border: 1px solid var(--line); border-radius: 24px; overflow: hidden; }

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -107,11 +107,13 @@ const state = {
   shopping: { meat: [], seasoning: [], sauceIngredients: [], sideIngredients: [], drinks: [] },
   shoppingChecks: {},
   butchers: [],
-  location: null
+  location: null,
+  variationCount: 0
 };
 
 const el = {
   appRoot: document.getElementById("app"),
+  openingSplash: document.getElementById("openingSplash"),
   header: document.getElementById("appHeader"),
   title: document.getElementById("screenTitle"),
   subtitle: document.getElementById("screenSubtitle"),
@@ -158,6 +160,9 @@ function render() {
   el.content.classList.remove("fade-in");
   void el.content.offsetWidth;
   el.content.classList.add("fade-in");
+  el.appRoot.classList.remove("screen-transition");
+  void el.appRoot.offsetWidth;
+  el.appRoot.classList.add("screen-transition");
 
   if (step === "landing") return renderLanding();
   if (step === "hot") return renderHotNow();
@@ -332,6 +337,7 @@ async function loadRecipe() {
     dietaryPreference: p.dietaryPreference,
     servings: String(p.servings),
     mode: "all",
+    variation: state.variationCount ? "1" : "0",
     r: String(Math.floor(Math.random() * 1000000))
   });
 
@@ -342,10 +348,7 @@ async function loadRecipe() {
 }
 
 function recipeHeroForCut() {
-  const cutId = state.preferences.cutId;
-  if (cutId === "brisket") return "url('/app/assets/recipe-brisket.jpg')";
-  if (cutId === "picanha") return "url('/app/assets/recipe-picanha.jpg')";
-  return "url('/app/assets/recipe-steak.jpg')";
+  return "url('/app/assets/recipe-card-bg.jpg')";
 }
 
 function renderRecipe() {
@@ -366,11 +369,23 @@ function renderRecipe() {
   const cook = main.cookTime || (state.lang === "he" ? "45 דקות" : "45 min");
   const total = main.totalTime || (state.lang === "he" ? "65 דקות" : "65 min");
   const difficulty = main.difficulty || (state.lang === "he" ? "בינוני" : "Medium");
+  const kosherLabel = state.preferences.dietaryPreference === "kosher" ? (state.lang === "he" ? "כשר" : "Kosher") : (state.lang === "he" ? "לא כשר" : "Non-kosher");
+  const badges = [
+    { label: state.lang === "he" ? "סה״כ זמן" : "Total Time", value: total },
+    { label: state.lang === "he" ? "קושי" : "Difficulty", value: difficulty },
+    { label: state.lang === "he" ? "מנות" : "Servings", value: state.preferences.servings },
+    { label: state.lang === "he" ? "כשרות" : "Diet", value: kosherLabel }
+  ];
+  const chefTips = getChefTips(state.preferences.cutId, state.preferences.methodId);
 
   el.content.innerHTML = `
     <div class="card recipe-hero" style="--recipe-image:${recipeHeroForCut()}">
       <h2>${main.title || (state.lang === "he" ? "מתכון פרימיום" : "Premium Recipe")}</h2>
       <p class="small">${main.description || ""}</p>
+    </div>
+
+    <div class="badges-row">
+      ${badges.map((badge) => `<span class="badge"><strong>${badge.label}</strong> ${badge.value}</span>`).join("")}
     </div>
 
     <div class="card meta-grid">
@@ -382,7 +397,7 @@ function renderRecipe() {
       <div class="meta-item"><strong>${state.lang === "he" ? "שיטת בישול" : "Cooking method"}</strong>${selectedMethod}</div>
       <div class="meta-item"><strong>${state.lang === "he" ? "פרופיל טעמים" : "Flavor profile"}</strong>${selectedFlavor}</div>
       <div class="meta-item"><strong>${state.lang === "he" ? "מנות" : "Servings"}</strong>${state.preferences.servings}</div>
-      <div class="meta-item"><strong>${state.lang === "he" ? "העדפת כשרות" : "Dietary preference"}</strong>${state.preferences.dietaryPreference === "kosher" ? (state.lang === "he" ? "כשר" : "Kosher") : (state.lang === "he" ? "לא כשר" : "Non-kosher")}</div>
+      <div class="meta-item"><strong>${state.lang === "he" ? "העדפת כשרות" : "Dietary preference"}</strong>${kosherLabel}</div>
     </div>
 
     <div class="card"><h3>${state.lang === "he" ? "מרכיבים" : "Ingredients"}</h3><ul class="list">${(main.ingredients || []).map((i) => `<li>${i}</li>`).join("")}</ul></div>
@@ -390,14 +405,26 @@ function renderRecipe() {
     <div class="card"><h3>${state.lang === "he" ? "רטבים" : "Sauces"}</h3><ul class="list">${(r.sauces || []).map((s) => `<li>${s.name}</li>`).join("")}</ul></div>
     <div class="card"><h3>${state.lang === "he" ? "תוספות" : "Side Dishes"}</h3><ul class="list">${(r.sides || []).map((s) => `<li>${s.name}</li>`).join("")}</ul></div>
     <div class="card"><h3>${state.lang === "he" ? "שתייה מתאימה" : "Drink Pairings"}</h3><ul class="list">${(r.drinkPairings || []).map((d) => `<li>${d.name}</li>`).join("")}</ul></div>
+    <div class="card">
+      <h3>${state.lang === "he" ? "טיפים מהשף" : "Chef Tips"}</h3>
+      <ul class="list">${chefTips.map((tip) => `<li>${tip}</li>`).join("")}</ul>
+    </div>
 
     <div class="inline-actions">
+      <button class="btn btn-ghost" id="copyShoppingBtn">${state.lang === "he" ? "📋 העתק רשימת קניות" : "📋 Copy Shopping List"}</button>
+      <button class="btn btn-ghost" id="variationBtn">${state.lang === "he" ? "🔄 נסה וריאציה" : "🔄 Try Variation"}</button>
       <button class="btn btn-ghost" id="regenBtn">${state.lang === "he" ? "צור מתכון מחדש" : "Regenerate Recipe"}</button>
       <button class="btn btn-ghost" id="servingBtn">${state.lang === "he" ? "שנה מספר מנות" : "Change Servings"}</button>
       <button class="btn btn-primary" id="toShoppingBtn">${state.lang === "he" ? "המשך לרשימת קניות" : "Continue to Shopping List"}</button>
     </div>
   `;
 
+  document.getElementById("copyShoppingBtn").addEventListener("click", () => copyShoppingListToClipboard());
+  document.getElementById("variationBtn").addEventListener("click", async () => {
+    state.variationCount += 1;
+    state.recipe = null;
+    renderRecipe();
+  });
   document.getElementById("regenBtn").addEventListener("click", async () => {
     state.recipe = null;
     renderRecipe();
@@ -454,7 +481,7 @@ function renderShopping() {
         </div>`;
     }).join("")}
 
-    <button class="btn btn-ghost" id="copyList">${state.lang === "he" ? "העתק רשימה" : "Copy list"}</button>
+    <button class="btn btn-ghost" id="copyList">${state.lang === "he" ? "📋 העתק רשימת קניות" : "📋 Copy Shopping List"}</button>
     <button class="btn btn-primary" id="toButchers">${state.lang === "he" ? "המשך לאיתור קצביות" : "Continue to butcher finder"}</button>
   `;
 
@@ -464,15 +491,7 @@ function renderShopping() {
     });
   });
 
-  document.getElementById("copyList").addEventListener("click", async () => {
-    const list = Object.values(state.shopping).flat().join("\n");
-    try {
-      await navigator.clipboard.writeText(list);
-      alert(state.lang === "he" ? "הרשימה הועתקה" : "List copied");
-    } catch {
-      alert(state.lang === "he" ? "לא הצלחנו להעתיק" : "Copy failed");
-    }
-  });
+  document.getElementById("copyList").addEventListener("click", async () => copyShoppingListToClipboard());
   document.getElementById("toButchers").addEventListener("click", () => {
     currentStep = 6;
     render();
@@ -508,15 +527,28 @@ function renderButchers() {
     return;
   }
 
+  const distances = state.butchers.map((item) => getDistanceValue(item)).filter((v) => Number.isFinite(v));
+  const closestDistance = distances.length ? Math.min(...distances) : NaN;
+
   el.content.innerHTML = `
-    <div class="card visual-map"><h3>${state.lang === "he" ? "קצביות מומלצות באזור שלך" : "Top butcher shops near you"}</h3></div>
-    ${state.butchers.slice(0, 8).map((b) => {
+    <div class="card visual-map">
+      <h3>${state.lang === "he" ? "קצביות מומלצות באזור שלך" : "Top butcher shops near you"}</h3>
+      <p class="small">${state.lang === "he" ? "תצוגת מפה חכמה עם נקודות סימון כתומות." : "Smart map-style visual with orange location pins."}</p>
+    </div>
+    ${state.butchers.slice(0, 8).map((b, idx) => {
       const stars = "⭐".repeat(Math.max(1, Math.min(5, Math.round(b.rating || 4))));
+      const distance = getDistanceValue(b);
+      const isClosest = Number.isFinite(distance) && Number.isFinite(closestDistance) && distance === closestDistance;
+      const badges = [
+        idx === 0 ? (state.lang === "he" ? "מומלץ לידך" : "Recommended Near You") : "",
+        isClosest ? (state.lang === "he" ? "הכי קרוב" : "Closest") : ""
+      ].filter(Boolean);
       return `
-        <article class="card">
+        <article class="card butcher-card ${idx === 0 ? "featured" : ""}">
+          ${badges.length ? `<div class="badges-row">${badges.map((badge) => `<span class="badge badge-emphasis">${badge}</span>`).join("")}</div>` : ""}
           <strong>📍 ${b.name}</strong>
           <p class="small">${b.address || ""}</p>
-          <p class="small">${stars} ${b.rating || "-"} (${b.userRatingsTotal || 0})</p>
+          <p class="small">${stars} ${b.rating || "-"} (${b.userRatingsTotal || 0}) ${Number.isFinite(distance) ? `• ${distance.toFixed(1)} km` : ""}</p>
           <a class="btn btn-primary" href="${b.mapsUrl}" target="_blank" rel="noopener">${state.lang === "he" ? "פתח במפות" : "Open in Maps"}</a>
         </article>`;
     }).join("")}
@@ -538,4 +570,59 @@ async function handleNext() {
   }
 }
 
-render();
+function getDistanceValue(shop) {
+  const candidates = [shop.distanceKm, shop.distance_km, shop.distance, shop.distanceMeters ? shop.distanceMeters / 1000 : null];
+  const first = candidates.find((v) => typeof v === "number" && Number.isFinite(v));
+  if (Number.isFinite(first)) return first;
+  if (typeof shop.distanceText === "string") {
+    const parsed = Number(shop.distanceText.replace(/[^\d.]/g, ""));
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return NaN;
+}
+
+function getChefTips(cutId, methodId) {
+  const tipBank = {
+    he: {
+      grill: ["חמם את הרשת היטב לפני שהבשר עולה עליה.", "הפוך את הנתח פעם אחת בלבד לקבלת צריבה טובה.", "תן לבשר לנוח 5–7 דקות לפני פריסה."],
+      smoker: ["שמור על טמפרטורה יציבה לאורך כל העישון.", "רסס מעט נוזלים כל שעה לשמירה על לחות.", "עטוף את הנתח כשהקליפה מתייצבת."],
+      cast_iron: ["ייבש את הנתח לפני הצריבה לקבלת קרסט מושלם.", "אל תעמיס מחבת — נתח אחד בכל פעם.", "סיים עם חמאה ועשבי תיבול בארבעים השניות האחרונות."],
+      default: ["תבל מראש ותן לבשר 20 דקות בטמפרטורת חדר.", "השתמש במדחום פנימי כדי לדייק בדרגת עשייה.", "מנוחה קצרה לפני חיתוך תשמור על עסיסיות."]
+    },
+    en: {
+      grill: ["Preheat the grates fully before adding the meat.", "Flip once for a stronger crust.", "Rest the meat 5–7 minutes before slicing."],
+      smoker: ["Keep smoker temperature steady throughout the cook.", "Spritz lightly every hour to maintain moisture.", "Wrap once bark sets to push through the stall."],
+      cast_iron: ["Pat the cut dry before searing for better crust.", "Avoid crowding the pan—one cut at a time.", "Finish with butter and herbs in the final 40 seconds."],
+      default: ["Season early and rest the meat 20 minutes at room temp.", "Use an internal thermometer for accurate doneness.", "A short rest before slicing keeps juices inside."]
+    }
+  };
+
+  const methodTips = tipBank[state.lang][methodId] || tipBank[state.lang].default;
+  if (cutId === "brisket" || cutId === "short_ribs") {
+    return state.lang === "he"
+      ? ["לנתחים קשים יותר תן זמן בישול ארוך ועדין.", "המתן עד לרכות לפני פריסה.", "פרוס נגד הסיבים להגשה רכה יותר."]
+      : ["For tougher cuts, give them low, steady time.", "Wait for tenderness before slicing.", "Slice against the grain for a softer bite."];
+  }
+  return methodTips.slice(0, 3);
+}
+
+async function copyShoppingListToClipboard() {
+  const list = Object.values(state.shopping).flat().join("\n");
+  try {
+    await navigator.clipboard.writeText(list);
+    alert(state.lang === "he" ? "הרשימה הועתקה" : "List copied");
+  } catch {
+    alert(state.lang === "he" ? "לא הצלחנו להעתיק" : "Copy failed");
+  }
+}
+
+function initOpeningAnimation() {
+  render();
+  if (!el.openingSplash) return;
+  const revealDelayMs = 950;
+  window.setTimeout(() => {
+    el.openingSplash.classList.add("is-hidden");
+  }, revealDelayMs);
+}
+
+initOpeningAnimation();

--- a/public/app/assets/README.md
+++ b/public/app/assets/README.md
@@ -5,10 +5,8 @@ The app supports optional campaign-style image assets in this folder.
 Recommended files:
 - `app-bg-smoke.jpg`
 - `hero-steak.jpg`
-- `hot-trends.jpg`
-- `butcher-map.jpg`
-- `recipe-brisket.jpg`
-- `recipe-steak.jpg`
-- `recipe-picanha.jpg`
+- `butcher-map-bg.jpg`
+- `recipe-card-bg.jpg`
+- `hot-trends-bg.jpg`
 
-If these files are not present, the app still renders with layered dark gradients, smoke-like overlays, and ember highlights.
+If these files are not present, the app still renders with layered dark gradients, smoke-like overlays, ember highlights, and CSS-generated map/radar accents.

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -9,6 +9,10 @@
   <link rel="stylesheet" href="/app/app.css" />
 </head>
 <body>
+  <div id="openingSplash" class="opening-splash" aria-hidden="true">
+    <div class="opening-logo">🔥 Smoke Radar</div>
+  </div>
+
   <main id="app" class="app-shell" data-step="landing">
     <header id="appHeader" class="app-header">
       <p class="brand">🔥 Smoke Radar</p>


### PR DESCRIPTION
### Motivation
- Give the isolated mobile app a stronger, app-like first impression with a lightweight opening animation and smoother screen transitions.
- Make recipe screens more useful in-flow by adding quick actions (copy, variation) and concise metadata so users can act immediately.
- Improve the butcher finder experience with a readable map-style header, meaningful highlights (recommended/closest), and robust distance handling while preparing for a visual asset pass.

### Description
- Added a short opening splash (`#openingSplash`) with smoke/radar glow and a ~950ms reveal, and added a subtle `screen-transition` animation for smoother screen changes. (files: `public/app/index.html`, `public/app/app.js`, `public/app/app.css`)
- Upgraded the recipe screen with compact badges (total time, difficulty, servings, kosher/non-kosher), a contextual "Chef Tips" section, a `📋 Copy Shopping List` action, and a `🔄 Try Variation` action that requests a recipe variation while preserving cut/method/kosher/servings via a `variation` query flag. (file: `public/app/app.js`, `public/app/app.css`)
- Polished butcher finder cards by adding a CSS map-style visual header (dark/radar accents + optional background), highlighting the top result with `מומלץ לידך` / `Recommended Near You`, marking the closest result with `הכי קרוב` / `Closest` when distance data exists, and robustly parsing multiple possible distance fields while preserving API-provided names/addresses. (file: `public/app/app.js`, `public/app/app.css`)
- Prepared optional image/asset slots and graceful fallbacks (gradients, smoke overlays, map accents) and updated `public/app/assets/README.md` to list the optional campaign images; added mobile-friendly micro-interactions (button/card press, hover effects, CTA glow). (files: `public/app/assets/README.md`, `public/app/app.css`)

### Testing
- Ran a JavaScript syntax check with `node --check public/app/app.js`, which completed successfully. 
- An attempt to run `node --check public/app/app.css` failed because Node does not support checking `.css` files, so CSS was validated by inspection and the app falls back safely when assets are missing.
- Verified repository changes (diff and commit) showing only `public/app/*` files were modified and the dashboard was not touched.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc9a37b40832fa3c7b1a3fb9f33ef)