### PR TITLE
Fix mobile UX in public/app: landing headline, RTL shopping, butcher layout, sub-recipes

### DIFF
--- a/public/app/app.css
+++ b/public/app/app.css
@@ -72,9 +72,17 @@ body {
   background-position: center;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45), inset 0 0 80px rgba(0,0,0,0.42);
 }
+.app-header.landing-minimal {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
 .brand { margin: 0; color: var(--accent-soft); font-weight: 800; text-transform: uppercase; letter-spacing: .03em; }
 #screenTitle { margin: 8px 0 0; font-size: clamp(1.55rem, 5.2vw, 2.4rem); line-height: 1.05; font-weight: 900; }
 .hero-subtitle { margin: 6px 0 0; color: var(--muted); font-size: .92rem; }
+.app-header.landing-minimal #screenTitle,
+.app-header.landing-minimal .hero-subtitle {
+  display: none;
+}
 
 .progress-wrap { margin-top: 10px; display: grid; gap: 4px; }
 .progress-text { font-size: .78rem; color: #f5be93; }
@@ -182,6 +190,10 @@ body {
 .btn:hover { transform: translateY(-1px); }
 .card:hover { transform: translateY(-1px); border-color: rgba(255, 141, 89, .3); }
 .butcher-card.featured { border-color: rgba(255, 139, 81, .55); box-shadow: inset 0 0 0 1px rgba(255, 139, 81, .2); }
+.butcher-meta-row { margin-top: 8px; }
+.butcher-rating { margin: 0; word-break: break-word; }
+.butcher-action-row { margin-top: 10px; }
+.butcher-action-row .btn { margin: 0; }
 
 .screen-transition { animation: stepShift .24s ease; }
 
@@ -191,6 +203,16 @@ body {
 .inline-actions { display: grid; gap: 8px; }
 .group-title { margin: 0 0 8px; color: var(--accent-soft); font-size: .87rem; }
 .check-item { display: flex; align-items: center; gap: 10px; padding: 7px 0; border-bottom: 1px dashed rgba(255,255,255,.09); }
+.check-item span { flex: 1; }
+.sub-recipe-block + .sub-recipe-block {
+  border-top: 1px dashed rgba(255, 255, 255, .15);
+  margin-top: 10px;
+  padding-top: 10px;
+}
+.sub-recipe-block h4 {
+  margin: 0 0 8px;
+  color: #ffd5bb;
+}
 .chips { display: flex; flex-wrap: wrap; gap: 8px; }
 .chip { padding: 6px 10px; border-radius: 999px; border: 1px solid var(--line); background: rgba(255,255,255,.03); font-size: .82rem; }
 .field { display: grid; gap: 5px; }
@@ -206,6 +228,14 @@ select, input {
 
 .hidden { display: none !important; }
 .fade-in { animation: fadeIn .28s ease; }
+
+html[dir="rtl"] .group-title,
+html[dir="rtl"] .check-item {
+  text-align: right;
+}
+html[dir="rtl"] .check-item {
+  flex-direction: row-reverse;
+}
 
 @keyframes fadeIn { from { opacity: .15; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes splashPulse {

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -117,6 +117,7 @@ const el = {
   header: document.getElementById("appHeader"),
   title: document.getElementById("screenTitle"),
   subtitle: document.getElementById("screenSubtitle"),
+  progressWrap: document.querySelector(".progress-wrap"),
   content: document.getElementById("screenContent"),
   nextBtn: document.getElementById("nextBtn"),
   backBtn: document.getElementById("backBtn"),
@@ -148,8 +149,10 @@ function render() {
   document.documentElement.lang = state.lang;
   document.documentElement.dir = t("dir");
   el.appRoot.dataset.step = step;
-  el.title.textContent = t(`titles.${step}`);
-  el.subtitle.textContent = step === "landing" ? t("landingSubtitle") : "";
+  el.title.textContent = step === "landing" ? "" : t(`titles.${step}`);
+  el.subtitle.textContent = "";
+  el.header.classList.toggle("landing-minimal", step === "landing");
+  el.progressWrap?.classList.toggle("hidden", step === "landing");
   el.progressFill.style.width = `${progress}%`;
   el.progressText.textContent = `${t("stepLabel")} ${Math.max(currentStep, 1)}/${totalFlowSteps}`;
   el.backBtn.textContent = t("back");
@@ -377,6 +380,8 @@ function renderRecipe() {
     { label: state.lang === "he" ? "כשרות" : "Diet", value: kosherLabel }
   ];
   const chefTips = getChefTips(state.preferences.cutId, state.preferences.methodId);
+  const sauces = normalizeSubRecipes(r.sauces, "sauce");
+  const sides = normalizeSubRecipes(r.sides, "side");
 
   el.content.innerHTML = `
     <div class="card recipe-hero" style="--recipe-image:${recipeHeroForCut()}">
@@ -402,8 +407,14 @@ function renderRecipe() {
 
     <div class="card"><h3>${state.lang === "he" ? "מרכיבים" : "Ingredients"}</h3><ul class="list">${(main.ingredients || []).map((i) => `<li>${i}</li>`).join("")}</ul></div>
     <div class="card"><h3>${state.lang === "he" ? "שלבי הכנה" : "Step-by-step"}</h3><ol class="list">${(main.steps || []).map((s) => `<li>${s}</li>`).join("")}</ol></div>
-    <div class="card"><h3>${state.lang === "he" ? "רטבים" : "Sauces"}</h3><ul class="list">${(r.sauces || []).map((s) => `<li>${s.name}</li>`).join("")}</ul></div>
-    <div class="card"><h3>${state.lang === "he" ? "תוספות" : "Side Dishes"}</h3><ul class="list">${(r.sides || []).map((s) => `<li>${s.name}</li>`).join("")}</ul></div>
+    <div class="card">
+      <h3>${state.lang === "he" ? "רטבים" : "Sauces"}</h3>
+      ${renderSubRecipeDetails(sauces)}
+    </div>
+    <div class="card">
+      <h3>${state.lang === "he" ? "תוספות" : "Side Dishes"}</h3>
+      ${renderSubRecipeDetails(sides)}
+    </div>
     <div class="card"><h3>${state.lang === "he" ? "שתייה מתאימה" : "Drink Pairings"}</h3><ul class="list">${(r.drinkPairings || []).map((d) => `<li>${d.name}</li>`).join("")}</ul></div>
     <div class="card">
       <h3>${state.lang === "he" ? "טיפים מהשף" : "Chef Tips"}</h3>
@@ -446,8 +457,8 @@ function renderRecipe() {
 
 function buildShoppingList(recipe) {
   const mainIng = recipe?.main?.ingredients || [];
-  const sauces = (recipe?.sauces || []).flatMap((s) => s.ingredients || [s.name]).filter(Boolean);
-  const sides = (recipe?.sides || []).flatMap((s) => s.ingredients || [s.name]).filter(Boolean);
+  const sauces = normalizeSubRecipes(recipe?.sauces, "sauce").flatMap((s) => s.ingredients);
+  const sides = normalizeSubRecipes(recipe?.sides, "side").flatMap((s) => s.ingredients);
   const drinks = (recipe?.drinkPairings || []).map((d) => d.name).filter(Boolean);
 
   return {
@@ -476,7 +487,7 @@ function renderShopping() {
           <h3 class="group-title">${group[state.lang]}</h3>
           ${items.length ? items.map((item, idx) => {
             const id = `${group.key}-${idx}`;
-            return `<label class="check-item"><input type="checkbox" data-check="${id}" ${state.shoppingChecks[id] ? "checked" : ""} /> <span>${item}</span></label>`;
+            return `<label class="check-item"><span>${item}</span><input type="checkbox" data-check="${id}" ${state.shoppingChecks[id] ? "checked" : ""} /></label>`;
           }).join("") : `<p class="small">${state.lang === "he" ? "לא נוספו פריטים" : "No items added"}</p>`}
         </div>`;
     }).join("")}
@@ -548,11 +559,78 @@ function renderButchers() {
           ${badges.length ? `<div class="badges-row">${badges.map((badge) => `<span class="badge badge-emphasis">${badge}</span>`).join("")}</div>` : ""}
           <strong>📍 ${b.name}</strong>
           <p class="small">${b.address || ""}</p>
-          <p class="small">${stars} ${b.rating || "-"} (${b.userRatingsTotal || 0}) ${Number.isFinite(distance) ? `• ${distance.toFixed(1)} km` : ""}</p>
-          <a class="btn btn-primary" href="${b.mapsUrl}" target="_blank" rel="noopener">${state.lang === "he" ? "פתח במפות" : "Open in Maps"}</a>
+          <div class="butcher-meta-row">
+            <p class="small butcher-rating">${stars} ${b.rating || "-"} (${b.userRatingsTotal || 0}) ${Number.isFinite(distance) ? `• ${distance.toFixed(1)} km` : ""}</p>
+          </div>
+          <div class="butcher-action-row">
+            <a class="btn btn-primary" href="${b.mapsUrl}" target="_blank" rel="noopener">${state.lang === "he" ? "פתח במפות" : "Open in Maps"}</a>
+          </div>
         </article>`;
     }).join("")}
   `;
+}
+
+function normalizeSubRecipes(items, type) {
+  const list = Array.isArray(items) ? items : [];
+  const normalized = list.map((item) => ({
+    title: item?.name || defaultSubRecipe(type).title,
+    ingredients: (item?.ingredients || []).filter(Boolean),
+    steps: (item?.steps || []).filter(Boolean)
+  }));
+
+  if (!normalized.length) return [defaultSubRecipe(type)];
+
+  return normalized.map((item) => {
+    const fallback = defaultSubRecipe(type, item.title);
+    return {
+      title: item.title || fallback.title,
+      ingredients: item.ingredients.length ? item.ingredients : fallback.ingredients,
+      steps: item.steps.length ? item.steps : fallback.steps
+    };
+  });
+}
+
+function defaultSubRecipe(type, explicitTitle) {
+  if (state.lang === "he") {
+    if (type === "sauce") {
+      return {
+        title: explicitTitle || "צ'ימיצ'ורי קלאסי",
+        ingredients: ["1/2 כוס פטרוזיליה קצוצה", "2 שיני שום כתושות", "3 כפות שמן זית", "1 כף חומץ יין אדום", "מלח ופלפל לפי הטעם"],
+        steps: ["מערבבים בקערה את כל המרכיבים.", "טועמים ומאזנים מלח/חומץ.", "מגישים לצד הבשר או מעליו."]
+      };
+    }
+    return {
+      title: explicitTitle || "תפוחי אדמה מעושנים",
+      ingredients: ["4 תפוחי אדמה בינוניים חתוכים", "2 כפות שמן זית", "1 כפית פפריקה מעושנת", "1/2 כפית מלח", "1/4 כפית פלפל שחור"],
+      steps: ["מערבבים את תפוחי האדמה עם התיבול.", "צולים בתנור או על הגריל עד הזהבה.", "מגישים חם לצד המנה העיקרית."]
+    };
+  }
+
+  if (type === "sauce") {
+    return {
+      title: explicitTitle || "Classic Chimichurri",
+      ingredients: ["1/2 cup chopped parsley", "2 minced garlic cloves", "3 tbsp olive oil", "1 tbsp red wine vinegar", "Salt and pepper to taste"],
+      steps: ["Combine all ingredients in a bowl.", "Adjust seasoning and acidity.", "Serve over or beside the meat."]
+    };
+  }
+  return {
+    title: explicitTitle || "Smoky Roasted Potatoes",
+    ingredients: ["4 medium potatoes, cubed", "2 tbsp olive oil", "1 tsp smoked paprika", "1/2 tsp salt", "1/4 tsp black pepper"],
+    steps: ["Toss potatoes with oil and seasoning.", "Roast or grill until golden and tender.", "Serve hot next to the main dish."]
+  };
+}
+
+function renderSubRecipeDetails(items) {
+  if (!items.length) return `<p class="small">${state.lang === "he" ? "לא נוספו פריטים" : "No items added"}</p>`;
+  return items.map((item) => `
+    <div class="sub-recipe-block">
+      <h4>${item.title}</h4>
+      <p class="small">${state.lang === "he" ? "מרכיבים" : "Ingredients"}</p>
+      <ul class="list">${item.ingredients.map((ingredient) => `<li>${ingredient}</li>`).join("")}</ul>
+      <p class="small">${state.lang === "he" ? "הכנה" : "Instructions"}</p>
+      <ol class="list">${item.steps.map((step) => `<li>${step}</li>`).join("")}</ol>
+    </div>
+  `).join("");
 }
 
 async function handleNext() {


### PR DESCRIPTION
### Motivation
- Address a focused set of mobile UX bugs inside the isolated app flow under `public/app/` without touching the dashboard at `/`. 
- Remove repeated/home headline, improve Hebrew (RTL) shopping list rendering, prevent butcher card action overlap on narrow screens, and surface full sauce/side recipes so shopping lists include their ingredients.

### Description
- Hide the top header title/subtitle on the landing step and keep the hero card headline, controlled by a new `landing-minimal` header class toggled in `render()` to remove the duplicate landing headline. 
- Adjust header/progress visibility on landing by toggling the `.progress-wrap` visibility in `render()` so the landing screen feels minimal and premium. 
- Swap checkbox/text order in shopping rows and add RTL CSS rules so Hebrew mode shows right-aligned group headings and naturally ordered check-item rows while English remains LTR. 
- Refactor butcher card markup to separate rating metadata (`.butcher-meta-row`) from the map action (`.butcher-action-row`) and add small CSS rules so the `Open in Maps` button no longer overlaps ratings on narrow screens. 
- Add structured handling for sauces and sides: `normalizeSubRecipes`, `defaultSubRecipe` (localized Hebrew/English fallbacks), and `renderSubRecipeDetails` to render full title, ingredient list, and step-by-step instructions on the recipe screen. 
- Ensure `buildShoppingList()` now includes normalized sauce and side ingredients so shopping lists merge main + sauce + side items consistently.
- Files changed: `public/app/app.js` and `public/app/app.css` (all edits confined to `public/app/`).

### Testing
- Ran JavaScript syntax check: `node --check public/app/app.js` (succeeded). 
- No automated CSS linter was run because `node --check` does not validate CSS; visual verification is expected in manual QA on device/emulator.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebce2201d8832f871c1f71bea3b20a)