### PR TITLE
Polish home screen visuals and robust asset loading for Smoke Radar app

### DIFF
--- a/public/app/app.css
+++ b/public/app/app.css
@@ -7,6 +7,11 @@
   --line: rgba(255, 255, 255, 0.11);
   --accent: #ff6b2c;
   --accent-soft: #ffb07c;
+  --asset-app-bg: none;
+  --asset-hero: none;
+  --asset-hot: none;
+  --asset-recipe: none;
+  --asset-butcher: none;
 }
 
 * { box-sizing: border-box; }
@@ -18,7 +23,7 @@ body {
     radial-gradient(circle at 10% 8%, rgba(255, 115, 40, 0.22), transparent 35%),
     radial-gradient(circle at 80% 20%, rgba(255, 69, 0, 0.15), transparent 30%),
     linear-gradient(180deg, #050506 0%, #0a0b0f 45%, #090909 100%),
-    url('/app/assets/app-bg-smoke.jpg');
+    var(--asset-app-bg);
   background-size: cover, cover, cover, cover;
   background-position: center;
   color: var(--text);
@@ -36,7 +41,7 @@ body {
     radial-gradient(circle at 40% 38%, rgba(255, 89, 0, 0.24), transparent 36%),
     repeating-radial-gradient(circle at center, rgba(255, 125, 66, 0.11) 0 1px, transparent 1px 11px),
     linear-gradient(180deg, #050506 0%, #0d0e12 100%),
-    url('/app/assets/app-bg-smoke.jpg');
+    var(--asset-app-bg);
   background-size: cover;
   background-position: center;
   transition: opacity .35s ease, visibility .35s ease;
@@ -184,8 +189,9 @@ html[dir="ltr"] .opening-step.active { transform: translateX(2px); }
   border-radius: 24px;
   padding: 16px;
   background:
-    linear-gradient(180deg, rgba(10, 10, 12, 0.9), rgba(18, 12, 8, 0.82)),
-    url('/app/assets/hero-steak.jpg');
+    linear-gradient(180deg, rgba(7, 7, 9, 0.58), rgba(10, 8, 7, 0.88)),
+    radial-gradient(circle at 78% 20%, rgba(255, 111, 43, 0.35), transparent 45%),
+    var(--asset-hero);
   background-size: cover;
   background-position: center;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45), inset 0 0 80px rgba(0,0,0,0.42);
@@ -234,7 +240,7 @@ html[dir="ltr"] .opening-step.active { transform: translateX(2px); }
   background:
     linear-gradient(180deg, rgba(0,0,0,.2), rgba(0,0,0,.72)),
     radial-gradient(circle at 80% 20%, rgba(255, 123, 62, 0.35), transparent 45%),
-    url('/app/assets/hot-trends-bg.jpg');
+    var(--asset-hot);
   background-size: cover;
   background-position: center;
 }
@@ -247,7 +253,7 @@ html[dir="ltr"] .opening-step.active { transform: translateX(2px); }
     radial-gradient(circle at 80% 52%, rgba(255,111,52,.32) 0 5px, transparent 7px),
     repeating-linear-gradient(25deg, rgba(255,255,255,.06), rgba(255,255,255,.06) 1px, transparent 1px, transparent 13px),
     linear-gradient(180deg, rgba(6,9,12,.28), rgba(8,8,8,.86)),
-    url('/app/assets/butcher-map-bg.jpg');
+    var(--asset-butcher);
   background-size: cover;
   background-position: center;
 }
@@ -260,7 +266,7 @@ html[dir="ltr"] .opening-step.active { transform: translateX(2px); }
   background:
     linear-gradient(180deg, rgba(0,0,0,.2), rgba(0,0,0,.84)),
     radial-gradient(circle at 85% 12%, rgba(255, 124, 66, 0.34), transparent 45%),
-    var(--recipe-image, url('/app/assets/recipe-card-bg.jpg'));
+    var(--recipe-image, var(--asset-recipe));
   background-size: cover;
   background-position: center;
 }
@@ -304,6 +310,22 @@ html[dir="ltr"] .opening-step.active { transform: translateX(2px); }
   text-align: start;
 }
 .btn-choice.active { border-color: rgba(255,117,49,.65); box-shadow: inset 0 0 0 1px rgba(255,117,49,.45); }
+.btn-choice-hot {
+  background: linear-gradient(135deg, #ffb177 0%, #ff7a33 45%, #cc3300 100%);
+  border-color: rgba(255, 137, 78, 0.7);
+  box-shadow: 0 12px 24px rgba(255, 89, 31, 0.35);
+}
+.btn-choice-know {
+  background: linear-gradient(180deg, rgba(255, 141, 84, 0.22), rgba(255, 141, 84, 0.08));
+  border-color: rgba(255, 150, 96, 0.32);
+}
+.btn-choice-saved {
+  padding-block: 11px;
+  font-size: .95rem;
+  background: rgba(255,255,255,.025);
+  border-color: rgba(255,255,255,.14);
+  color: #d7d0c4;
+}
 .btn:active { transform: translateY(1px) scale(.99); filter: brightness(.98); }
 .btn:hover { transform: translateY(-1px); }
 .card:hover { transform: translateY(-1px); border-color: rgba(255, 141, 89, .3); }
@@ -352,14 +374,21 @@ html[dir="ltr"] .opening-step.active { transform: translateX(2px); }
 .legal-menu {
   display: grid;
   gap: 8px;
+  margin-top: 2px;
+  padding: 10px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015));
 }
 .legal-menu h3 {
   margin: 0 0 2px;
-  color: var(--accent-soft);
+  color: #c8b7a4;
+  font-size: .9rem;
+  font-weight: 700;
 }
 .footer-note {
   margin-top: 4px;
   opacity: 0.9;
+  font-size: .76rem;
 }
 .sub-recipe-block + .sub-recipe-block {
   border-top: 1px dashed rgba(255, 255, 255, .15);
@@ -370,8 +399,26 @@ html[dir="ltr"] .opening-step.active { transform: translateX(2px); }
   margin: 0 0 8px;
   color: #ffd5bb;
 }
-.chips { display: flex; flex-wrap: wrap; gap: 8px; }
-.chip { padding: 6px 10px; border-radius: 999px; border: 1px solid var(--line); background: rgba(255,255,255,.03); font-size: .82rem; }
+.chips { display: flex; flex-wrap: wrap; gap: 6px; opacity: .95; }
+.chip {
+  padding: 4px 9px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,.16);
+  background: rgba(255,255,255,.02);
+  font-size: .74rem;
+}
+.chip:nth-child(3n) {
+  border-color: rgba(255, 140, 84, 0.35);
+  color: #f2d7bf;
+}
+.hero-card h2 {
+  font-size: clamp(1.45rem, 5.6vw, 2.25rem);
+  margin: 0;
+  text-shadow: 0 6px 24px rgba(0,0,0,.58);
+}
+.hero-card .small {
+  color: #f3dbca;
+}
 .field { display: grid; gap: 5px; }
 label { color: var(--muted); font-size: .88rem; }
 select, input {

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -2,6 +2,15 @@ const STEPS = ["landing", "saved", "hot", "preferences", "cook", "recipe", "shop
 let currentStep = 0;
 const SAVED_RECIPES_KEY = "smoke_radar_saved_recipes_v1";
 const SHARE_TEXT = "Check out Smoke Radar — meat trends, recipes, and butcher discovery in one radar-style app.";
+const INTRO_MIN_DURATION_MS = 1800;
+
+const assetCandidates = {
+  appBg: ["/app/assets/app-bg-smoke.jpg", "/app/assets/app-bg-smoke.jpg.png"],
+  hero: ["/app/assets/hero-steak.jpg", "/app/assets/hero-steak.jpg.png"],
+  hot: ["/app/assets/hot-trends.jpg", "/app/assets/hot-trends-bg.jpg", "/app/assets/hot-trends.jpg.png", "/app/assets/hot-trends1.jpg.PNG"],
+  recipe: ["/app/assets/recipe-card-bg.jpg", "/app/assets/recipe-bg.jpg", "/app/assets/recipe-card-bg.jpg.png", "/app/assets/recipe-bg.jpg.png"],
+  butcher: ["/app/assets/butcher-map-bg.jpg", "/app/assets/butcher-map-bg.jpg.png"]
+};
 
 const cutsCatalog = [
   { id: "ribeye", labels: { he: "אנטריקוט", en: "Ribeye" }, aliases: ["ribeye", "אנטריקוט"] },
@@ -188,6 +197,40 @@ function getCutById(id) { return cutsCatalog.find((c) => c.id === id) || cutsCat
 function getMethodById(id) { return methods.find((m) => m.id === id) || methods[0]; }
 function getFlavorById(id) { return flavorProfiles.find((f) => f.id === id) || flavorProfiles[0]; }
 
+async function findFirstExistingAsset(candidates = []) {
+  for (const src of candidates) {
+    try {
+      const ok = await new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => resolve(true);
+        img.onerror = () => resolve(false);
+        img.src = src;
+      });
+      if (ok) return src;
+    } catch {
+      // Ignore and continue trying fallbacks.
+    }
+  }
+  return "";
+}
+
+async function applyResolvedAssets() {
+  const [appBg, hero, hot, recipe, butcher] = await Promise.all([
+    findFirstExistingAsset(assetCandidates.appBg),
+    findFirstExistingAsset(assetCandidates.hero),
+    findFirstExistingAsset(assetCandidates.hot),
+    findFirstExistingAsset(assetCandidates.recipe),
+    findFirstExistingAsset(assetCandidates.butcher)
+  ]);
+
+  const root = document.documentElement;
+  if (appBg) root.style.setProperty("--asset-app-bg", `url('${appBg}')`);
+  if (hero) root.style.setProperty("--asset-hero", `url('${hero}')`);
+  if (hot) root.style.setProperty("--asset-hot", `url('${hot}')`);
+  if (recipe) root.style.setProperty("--asset-recipe", `url('${recipe}')`);
+  if (butcher) root.style.setProperty("--asset-butcher", `url('${butcher}')`);
+}
+
 function render() {
   const step = STEPS[currentStep];
   const totalFlowSteps = STEPS.length - 1;
@@ -299,20 +342,20 @@ function stopOpeningExperience() {
 function renderLanding() {
   const latest = state.savedRecipes[0];
   el.content.innerHTML = `
-    <div class="card recipe-hero" style="--recipe-image:url('/app/assets/hero-steak.jpg')">
+    <div class="card recipe-hero hero-card" style="--recipe-image:var(--asset-hero)">
       <p class="small">${state.lang === "he" ? "Smoke Radar Premium" : "Smoke Radar Premium"}</p>
       <h2>${t("landingTitle")}</h2>
       <p class="small">${t("landingSubtitle")}</p>
     </div>
-    <button class="btn btn-choice" data-choice="hot">${t("hotAction")}</button>
-    <button class="btn btn-choice" data-choice="feel">${t("knowAction")}</button>
+    <button class="btn btn-choice btn-choice-hot" data-choice="hot">${t("hotAction")}</button>
+    <button class="btn btn-choice btn-choice-know" data-choice="feel">${t("knowAction")}</button>
     ${latest ? `
       <div class="card last-recipe-prompt">
         <p>${state.lang === "he" ? "להמשיך מהמתכון האחרון?" : "Continue your last recipe?"}</p>
         <button class="btn btn-ghost" id="openLastRecipeBtn">${state.lang === "he" ? "פתח מתכון אחרון" : "Open Last Recipe"}</button>
       </div>
     ` : ""}
-    <button class="btn btn-ghost" id="openSavedRecipesBtn">${state.lang === "he" ? "המתכונים שלי" : "My Recipes"}</button>
+    <button class="btn btn-choice btn-choice-saved" id="openSavedRecipesBtn">${state.lang === "he" ? "המתכונים שלי" : "My Recipes"}</button>
     <section class="card legal-menu">
       <h3>${state.lang === "he" ? "תפריט Smoke Radar" : "Smoke Radar Menu"}</h3>
       <button class="btn btn-ghost" id="aboutBtn">${state.lang === "he" ? "About Smoke Radar" : "About Smoke Radar"}</button>
@@ -536,7 +579,7 @@ async function loadRecipe() {
 }
 
 function recipeHeroForCut() {
-  return "url('/app/assets/recipe-card-bg.jpg')";
+  return "var(--asset-recipe)";
 }
 
 function renderRecipe() {
@@ -883,15 +926,16 @@ async function copyShoppingListToClipboard() {
 }
 
 function initOpeningAnimation() {
+  applyResolvedAssets();
   loadSavedRecipes();
   startOpeningExperience();
   render();
   if (!el.openingSplash) return;
-  window.requestAnimationFrame(() => {
+  window.setTimeout(() => {
     updateOpeningProgress(100);
     el.openingSplash.classList.add("is-hidden");
     stopOpeningExperience();
-  });
+  }, INTRO_MIN_DURATION_MS);
 }
 
 function saveCurrentRecipe() {


### PR DESCRIPTION
### Motivation
- Fix missing/incorrect image usage so campaign assets placed under `/app/assets/` are actually visible and fall back safely when absent.  
- Make the opening intro more noticeable (1.5–2s) while keeping it unobtrusive.  
- Improve visual hierarchy of the landing/hero area, differentiate the three main CTAs, reduce the dominance of chips/footer, and add smoky premium depth without changing the main dashboard route.

### Description
- Added runtime asset resolution in `public/app/app.js` using an `assetCandidates` map and `findFirstExistingAsset()` to probe multiple candidate filenames and bind the first valid URL to root CSS variables (`--asset-*`).  
- Applied resolved assets to the UI by setting CSS variables in `applyResolvedAssets()` and wiring them into CSS layers for app background, header hero, hot-trends card, butcher map, and recipe hero so images load when available and layered gradients remain as safe fallbacks.  
- Extended the opening splash visibility using `INTRO_MIN_DURATION_MS` (~1800ms) and a delayed hide to ensure the intro is noticeable but not annoying.  
- Improved landing visual hierarchy: added a `hero-card` for the main hero, increased headline presence, kept RTL behavior intact, and avoided duplicated text.  
- Differentiated the three main action buttons with distinct classes and styles: `btn-choice-hot` (strong fire/orange primary), `btn-choice-know` (secondary), and `btn-choice-saved` (calmer utility).  
- Polished chips and footer/menu area: smaller chip sizing, subtle color variation for chips, and softer, visually separated `legal-menu` styling to reduce dominance.  
- Files changed: `public/app/app.js`, `public/app/app.css`.

### Testing
- JavaScript syntax check passed: `node --check public/app/app.js` (success).  
- Basic verification confirmed only files under `public/app/` were modified (changes isolated to `public/app/app.js` and `public/app/app.css`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec998f1274832f9a7936f812f235fc)