### PR TITLE
Polish Smoke Radar app intro, loaders, servings UX, and butcher visuals

### DIFF
--- a/public/app/app.css
+++ b/public/app/app.css
@@ -252,10 +252,11 @@ html[dir="ltr"] .opening-step.active { transform: translateX(2px); }
     radial-gradient(circle at 58% 32%, rgba(255,111,52,.32) 0 5px, transparent 7px),
     radial-gradient(circle at 80% 52%, rgba(255,111,52,.32) 0 5px, transparent 7px),
     repeating-linear-gradient(25deg, rgba(255,255,255,.06), rgba(255,255,255,.06) 1px, transparent 1px, transparent 13px),
-    linear-gradient(180deg, rgba(6,9,12,.28), rgba(8,8,8,.86)),
+    linear-gradient(180deg, rgba(14,18,22,.18), rgba(8,8,8,.72)),
     var(--asset-butcher);
   background-size: cover;
   background-position: center;
+  filter: brightness(1.08) contrast(1.06);
 }
 
 .recipe-hero {
@@ -342,8 +343,13 @@ html[dir="ltr"] .opening-step.active { transform: translateX(2px); }
 .butcher-footer .btn {
   width: auto;
   min-width: 132px;
-  padding-inline: 14px;
+  padding: 10px 16px;
   margin: 0;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 
 .screen-transition { animation: stepShift .24s ease; }
@@ -362,6 +368,24 @@ html[dir="ltr"] .opening-step.active { transform: translateX(2px); }
   border-bottom: 1px dashed rgba(255,255,255,.09);
 }
 .check-item span { text-align: left; }
+.check-item input { margin-top: 2px; }
+.saved-recipe-card {
+  display: grid;
+  grid-template-columns: 74px 1fr;
+  gap: 10px;
+  align-items: start;
+}
+.saved-thumb {
+  width: 74px;
+  height: 74px;
+  object-fit: cover;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, .14);
+}
+.saved-recipe-content h3 {
+  margin-top: 0;
+  margin-bottom: 8px;
+}
 .saved-recipe-actions {
   margin-top: 10px;
   display: grid;
@@ -428,6 +452,71 @@ select, input {
   border: 1px solid var(--line);
   border-radius: 11px;
   padding: 11px;
+}
+.servings-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.servings-btn {
+  width: 42px;
+  min-width: 42px;
+  padding: 8px;
+  border-radius: 10px;
+  font-size: 1.1rem;
+}
+.recipe-servings-inline {
+  justify-content: center;
+  flex-wrap: wrap;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 8px;
+}
+.servings-label {
+  min-width: 100%;
+  text-align: center;
+}
+
+.branded-loader {
+  text-align: center;
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  min-height: 170px;
+  align-content: center;
+}
+.loading-radar {
+  width: 96px;
+}
+.loading-radar-small {
+  width: 84px;
+}
+.loading-dots span {
+  display: inline-block;
+  animation: loadingDots 1.1s infinite ease-in-out;
+}
+.loading-dots span:nth-child(2) { animation-delay: .15s; }
+.loading-dots span:nth-child(3) { animation-delay: .3s; }
+
+.app-toast {
+  position: fixed;
+  left: 50%;
+  bottom: calc(20px + env(safe-area-inset-bottom));
+  transform: translate(-50%, 12px);
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 173, 132, 0.32);
+  background: rgba(8, 8, 10, 0.95);
+  color: #ffe3d2;
+  font-weight: 700;
+  z-index: 70;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s ease, transform .22s ease;
+}
+.app-toast.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .hidden { display: none !important; }
@@ -519,6 +608,10 @@ html[dir="rtl"] .butcher-rating {
 @keyframes ctaGlow {
   0%, 100% { box-shadow: 0 0 0 1px rgba(255,121,56,.34), 0 12px 24px rgba(255,92,26,.26); }
   50% { box-shadow: 0 0 0 1px rgba(255,121,56,.5), 0 14px 30px rgba(255,92,26,.42); }
+}
+@keyframes loadingDots {
+  0%, 80%, 100% { opacity: .25; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-2px); }
 }
 
 @media (min-width: 700px) {

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -2,7 +2,7 @@ const STEPS = ["landing", "saved", "hot", "preferences", "cook", "recipe", "shop
 let currentStep = 0;
 const SAVED_RECIPES_KEY = "smoke_radar_saved_recipes_v1";
 const SHARE_TEXT = "Check out Smoke Radar — meat trends, recipes, and butcher discovery in one radar-style app.";
-const INTRO_MIN_DURATION_MS = 1800;
+const INTRO_MIN_DURATION_MS = 2600;
 
 const assetCandidates = {
   appBg: ["/app/assets/app-bg-smoke.jpg", "/app/assets/app-bg-smoke.jpg.png"],
@@ -73,6 +73,12 @@ const copy = {
       "בודקים מה הכי טרנדי עכשיו...",
       "כמעט שם..."
     ],
+    recipeLoadingMessages: [
+      "מחממים את הרדאר 🔥",
+      "מוצאים את השילוב המושלם...",
+      "בונים לך מתכון מדויק..."
+    ],
+    butcherLoadingMessage: "מחפש קצביות באזור שלך...",
     loadingSteps: [
       "🔥 מזהים טרנדים",
       "🥩 בוחרים נתח מושלם",
@@ -109,6 +115,12 @@ const copy = {
       "Scanning what's trending...",
       "Almost ready..."
     ],
+    recipeLoadingMessages: [
+      "Warming up the radar 🔥",
+      "Finding the perfect pairing...",
+      "Building your precise recipe..."
+    ],
+    butcherLoadingMessage: "Searching butcher shops near you...",
     loadingSteps: [
       "🔥 מזהים טרנדים",
       "🥩 בוחרים נתח מושלם",
@@ -151,7 +163,9 @@ const state = {
   location: null,
   variationCount: 0,
   savedRecipes: [],
-  lastOpenedRecipeId: null
+  lastOpenedRecipeId: null,
+  recipeLoading: false,
+  butcherLoading: false
 };
 
 const el = {
@@ -168,7 +182,8 @@ const el = {
   progressText: document.getElementById("progressText"),
   openingMessage: document.getElementById("openingMessage"),
   openingSteps: document.getElementById("openingSteps"),
-  openingProgressFill: document.getElementById("openingProgressFill")
+  openingProgressFill: document.getElementById("openingProgressFill"),
+  toast: document.getElementById("appToast")
 };
 
 const openingExperience = {
@@ -178,8 +193,12 @@ const openingExperience = {
   rafId: null,
   messageTimer: null,
   stepTimer: null,
-  running: false
+  running: false,
+  startTs: 0
 };
+
+let recipeLoadingInterval = null;
+let toastTimer = null;
 
 el.backBtn.addEventListener("click", () => {
   if (currentStep > 0) {
@@ -307,7 +326,8 @@ function startOpeningExperience() {
   openingExperience.running = true;
   openingExperience.messageIndex = 0;
   openingExperience.stepIndex = 0;
-  openingExperience.progress = 4;
+  openingExperience.progress = 1;
+  openingExperience.startTs = performance.now();
   updateOpeningMessage();
   renderOpeningStepList();
   updateOpeningProgress(openingExperience.progress);
@@ -317,14 +337,14 @@ function startOpeningExperience() {
     if (!messages.length) return;
     openingExperience.messageIndex = (openingExperience.messageIndex + 1) % messages.length;
     updateOpeningMessage();
-  }, 1250);
+  }, 820);
 
   openingExperience.stepTimer = window.setInterval(() => {
     const steps = t("loadingSteps") || [];
     if (!steps.length) return;
-    openingExperience.stepIndex = (openingExperience.stepIndex + 1) % steps.length;
+    openingExperience.stepIndex = Math.min(steps.length - 1, openingExperience.stepIndex + 1);
     renderOpeningStepList();
-  }, 1200);
+  }, Math.max(500, Math.round(INTRO_MIN_DURATION_MS / 4)));
 
   openingExperience.rafId = window.requestAnimationFrame(tickOpeningProgress);
 }
@@ -399,8 +419,11 @@ function renderSavedRecipes() {
     const cut = getCutById(item.preferences?.cutId || "ribeye").labels[state.lang];
     const method = getMethodById(item.preferences?.methodId || "grill").labels[state.lang];
     const date = formatSavedDate(item.createdAt);
+    const thumbnail = item.thumbnail || recipeThumbnailForCut(item.preferences?.cutId || "ribeye");
     return `
       <article class="card saved-recipe-card">
+        <img class="saved-thumb" src="${thumbnail}" alt="${item.title || "recipe"}" />
+        <div class="saved-recipe-content">
         <h3>${item.title || (state.lang === "he" ? "מתכון שמור" : "Saved Recipe")}</h3>
         <p class="small">${state.lang === "he" ? "נתח" : "Cut"}: ${cut}</p>
         <p class="small">${state.lang === "he" ? "שיטת בישול" : "Cooking method"}: ${method}</p>
@@ -408,6 +431,7 @@ function renderSavedRecipes() {
         <div class="saved-recipe-actions">
           <button class="btn btn-primary" data-open-recipe="${item.id}">${state.lang === "he" ? "פתח מתכון" : "Open Recipe"}</button>
           <button class="btn btn-ghost" data-delete-recipe="${item.id}">${state.lang === "he" ? "מחק" : "Delete"}</button>
+        </div>
         </div>
       </article>
     `;
@@ -500,16 +524,25 @@ function renderPreferences() {
           <option value="non_kosher">${state.lang === "he" ? "לא כשר" : "Non-kosher"}</option>
         </select>
       </div>
-      <div class="field"><label>${state.lang === "he" ? "מספר מנות" : "Servings"}</label><input type="number" min="1" max="20" id="servings" value="${state.preferences.servings}" /></div>
+      <div class="field">
+        <label>${state.lang === "he" ? "מנות" : "Servings"}</label>
+        <div class="servings-inline">
+          <button class="btn btn-ghost servings-btn" type="button" id="servingsMinus">−</button>
+          <strong id="servingsValue">${state.preferences.servings}</strong>
+          <button class="btn btn-ghost servings-btn" type="button" id="servingsPlus">+</button>
+        </div>
+      </div>
     </div>
   `;
 
-  ["meatType", "cutId", "methodId", "flavorId", "dietaryPreference", "servings"].forEach((id) => {
+  ["meatType", "cutId", "methodId", "flavorId", "dietaryPreference"].forEach((id) => {
     const input = document.getElementById(id);
     input.value = state.preferences[id];
     input.addEventListener("change", collectPreferences);
     input.addEventListener("input", collectPreferences);
   });
+  document.getElementById("servingsMinus")?.addEventListener("click", () => updateServings(-1, false));
+  document.getElementById("servingsPlus")?.addEventListener("click", () => updateServings(1, false));
 }
 
 function collectPreferences() {
@@ -518,7 +551,7 @@ function collectPreferences() {
   state.preferences.methodId = document.getElementById("methodId").value;
   state.preferences.flavorId = document.getElementById("flavorId").value;
   state.preferences.dietaryPreference = document.getElementById("dietaryPreference").value === "kosher" ? "kosher" : "non_kosher";
-  state.preferences.servings = Number(document.getElementById("servings").value || 1);
+  state.preferences.servings = Number(state.preferences.servings || 1);
 }
 
 function buildIdeas() {
@@ -584,10 +617,19 @@ function recipeHeroForCut() {
 
 function renderRecipe() {
   if (!state.recipe) {
-    el.content.innerHTML = `<div class="card">${state.lang === "he" ? "בונה מדריך בישול מלא..." : "Building your complete cooking guide..."}</div>`;
-    loadRecipe().then(renderRecipe).catch(() => {
-      el.content.innerHTML = `<div class="card">${state.lang === "he" ? "לא הצלחנו לטעון מתכון כרגע." : "Could not load recipe right now."}</div>`;
-    });
+    startRecipeLoadingState();
+    if (!state.recipeLoading) {
+      state.recipeLoading = true;
+      loadRecipe().then(() => {
+        stopRecipeLoadingState();
+        state.recipeLoading = false;
+        renderRecipe();
+      }).catch(() => {
+        stopRecipeLoadingState();
+        state.recipeLoading = false;
+        el.content.innerHTML = `<div class="card">${state.lang === "he" ? "לא הצלחנו לטעון מתכון כרגע." : "Could not load recipe right now."}</div>`;
+      });
+    }
     return;
   }
 
@@ -654,7 +696,12 @@ function renderRecipe() {
       <button class="btn btn-ghost" id="copyShoppingBtn">${state.lang === "he" ? "📋 העתק רשימת קניות" : "📋 Copy Shopping List"}</button>
       <button class="btn btn-ghost" id="variationBtn">${state.lang === "he" ? "🔄 נסה וריאציה" : "🔄 Try Variation"}</button>
       <button class="btn btn-ghost" id="regenBtn">${state.lang === "he" ? "צור מתכון מחדש" : "Regenerate Recipe"}</button>
-      <button class="btn btn-ghost" id="servingBtn">${state.lang === "he" ? "שנה מספר מנות" : "Change Servings"}</button>
+      <div class="servings-inline recipe-servings-inline">
+        <span class="small servings-label">${state.lang === "he" ? "מנות" : "Servings"}</span>
+        <button class="btn btn-ghost servings-btn" type="button" id="recipeServingsMinus">−</button>
+        <strong id="recipeServingsValue">${state.preferences.servings}</strong>
+        <button class="btn btn-ghost servings-btn" type="button" id="recipeServingsPlus">+</button>
+      </div>
       <button class="btn btn-primary" id="toShoppingBtn">${state.lang === "he" ? "המשך לרשימת קניות" : "Continue to Shopping List"}</button>
     </div>
   `;
@@ -672,15 +719,8 @@ function renderRecipe() {
     state.recipe = null;
     renderRecipe();
   });
-  document.getElementById("servingBtn").addEventListener("click", () => {
-    const v = window.prompt(state.lang === "he" ? "כמה מנות?" : "How many servings?", String(state.preferences.servings));
-    const servings = Number(v);
-    if (Number.isFinite(servings) && servings > 0 && servings <= 20) {
-      state.preferences.servings = servings;
-      state.recipe = null;
-      renderRecipe();
-    }
-  });
+  document.getElementById("recipeServingsMinus")?.addEventListener("click", () => updateServings(-1, true));
+  document.getElementById("recipeServingsPlus")?.addEventListener("click", () => updateServings(1, true));
   document.getElementById("toShoppingBtn").addEventListener("click", () => {
     currentStep = STEPS.indexOf("shopping");
     render();
@@ -719,7 +759,7 @@ function renderShopping() {
           <h3 class="group-title">${group[state.lang]}</h3>
           ${items.length ? items.map((item, idx) => {
             const id = `${group.key}-${idx}`;
-            return `<label class="check-item"><span>${item}</span><input type="checkbox" data-check="${id}" ${state.shoppingChecks[id] ? "checked" : ""} /></label>`;
+            return `<label class="check-item"><input type="checkbox" data-check="${id}" ${state.shoppingChecks[id] ? "checked" : ""} /><span>${item}</span></label>`;
           }).join("") : `<p class="small">${state.lang === "he" ? "לא נוספו פריטים" : "No items added"}</p>`}
         </div>`;
     }).join("")}
@@ -759,11 +799,14 @@ function renderButchers() {
       <button id="findButchers" class="btn btn-primary">${state.lang === "he" ? "📍 מצא קצביות קרובות" : "📍 Find nearby butcher shops"}</button>
     `;
     document.getElementById("findButchers").addEventListener("click", async () => {
-      el.content.innerHTML = `<div class="card">${state.lang === "he" ? "מאתר מיקום וקצביות..." : "Fetching your location and butcher shops..."}</div>`;
+      state.butcherLoading = true;
+      el.content.innerHTML = renderButcherLoading();
       try {
         await loadButchers();
+        state.butcherLoading = false;
         renderButchers();
       } catch {
+        state.butcherLoading = false;
         el.content.innerHTML = `<div class="card">${state.lang === "he" ? "נדרשת הרשאת מיקום כדי לאתר קצביות." : "Location permission is required to find butcher shops."}</div>`;
       }
     });
@@ -791,8 +834,9 @@ function renderButchers() {
           ${badges.length ? `<div class="badges-row">${badges.map((badge) => `<span class="badge badge-emphasis">${badge}</span>`).join("")}</div>` : ""}
           <strong>📍 ${b.name}</strong>
           <p class="small">${b.address || ""}</p>
+          <p class="small">${state.lang === "he" ? "מרחק ממך" : "Distance"}: ${Number.isFinite(distance) ? formatDistance(distance) : "-"}</p>
           <div class="butcher-footer">
-            <p class="small butcher-rating">${stars} ${b.rating || "-"} (${b.userRatingsTotal || 0}) ${Number.isFinite(distance) ? `• ${distance.toFixed(1)} km` : ""}</p>
+            <p class="small butcher-rating">${stars} ${b.rating || "-"} (${b.userRatingsTotal || 0})</p>
             <a class="btn btn-primary" href="${b.mapsUrl}" target="_blank" rel="noopener">${state.lang === "he" ? "פתח במפות" : "Open in Maps"}</a>
           </div>
         </article>`;
@@ -887,7 +931,22 @@ function getDistanceValue(shop) {
     const parsed = Number(shop.distanceText.replace(/[^\d.]/g, ""));
     if (Number.isFinite(parsed)) return parsed;
   }
+  if (state.location && Number.isFinite(shop?.lat) && Number.isFinite(shop?.lng)) {
+    return haversineDistanceKm(state.location.lat, state.location.lng, shop.lat, shop.lng);
+  }
+  if (state.location && Number.isFinite(shop?.latitude) && Number.isFinite(shop?.longitude)) {
+    return haversineDistanceKm(state.location.lat, state.location.lng, shop.latitude, shop.longitude);
+  }
   return NaN;
+}
+
+function haversineDistanceKm(lat1, lon1, lat2, lon2) {
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return 6371 * (2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)));
 }
 
 function getChefTips(cutId, methodId) {
@@ -934,7 +993,7 @@ function initOpeningAnimation() {
   window.setTimeout(() => {
     updateOpeningProgress(100);
     el.openingSplash.classList.add("is-hidden");
-    stopOpeningExperience();
+    window.setTimeout(() => stopOpeningExperience(), 380);
   }, INTRO_MIN_DURATION_MS);
 }
 
@@ -950,12 +1009,13 @@ function saveCurrentRecipe() {
     sides: state.recipe.sides || [],
     drinks: state.recipe.drinkPairings || [],
     shopping: state.shopping || {},
-    createdAt: new Date().toISOString()
+    createdAt: new Date().toISOString(),
+    thumbnail: recipeThumbnailForCut(state.preferences.cutId)
   };
   const withoutDupes = state.savedRecipes.filter((item) => item.id !== savedRecipe.id);
   state.savedRecipes = [savedRecipe, ...withoutDupes];
   persistSavedRecipes();
-  alert(state.lang === "he" ? "המתכון נשמר" : "Recipe saved");
+  showToast(state.lang === "he" ? "המתכון נשמר" : "Recipe saved");
 }
 
 function openSavedRecipe(id) {
@@ -1091,6 +1151,77 @@ async function shareSmokeRadar() {
   } catch {
     alert(state.lang === "he" ? "לא הצלחנו לשתף כרגע" : "Could not share right now");
   }
+}
+
+function recipeThumbnailForCut(cutId) {
+  if (["brisket", "short_ribs", "chuck"].includes(cutId)) return "/app/assets/recipe-bg.jpg.png";
+  return "/app/assets/hero-steak.jpg.png";
+}
+
+function updateServings(delta, rerenderRecipe) {
+  const next = Math.max(1, Math.min(20, Number(state.preferences.servings || 1) + delta));
+  if (next === state.preferences.servings) return;
+  state.preferences.servings = next;
+  const prefValue = document.getElementById("servingsValue");
+  if (prefValue) prefValue.textContent = String(next);
+  const recipeValue = document.getElementById("recipeServingsValue");
+  if (recipeValue) recipeValue.textContent = String(next);
+  if (rerenderRecipe) {
+    state.recipe = null;
+    renderRecipe();
+  }
+}
+
+function renderRecipeLoadingCard(message) {
+  return `
+    <div class="card branded-loader">
+      <div class="opening-radar-loader loading-radar" aria-hidden="true"><span></span></div>
+      <strong>${message}</strong>
+    </div>
+  `;
+}
+
+function startRecipeLoadingState() {
+  const messages = t("recipeLoadingMessages") || [];
+  let i = 0;
+  const print = () => {
+    const msg = messages[i % messages.length] || (state.lang === "he" ? "בונה מתכון..." : "Building recipe...");
+    el.content.innerHTML = renderRecipeLoadingCard(msg);
+    i += 1;
+  };
+  print();
+  if (recipeLoadingInterval) window.clearInterval(recipeLoadingInterval);
+  recipeLoadingInterval = window.setInterval(print, 850);
+}
+
+function stopRecipeLoadingState() {
+  if (recipeLoadingInterval) window.clearInterval(recipeLoadingInterval);
+  recipeLoadingInterval = null;
+}
+
+function renderButcherLoading() {
+  return `
+    <div class="card branded-loader">
+      <div class="opening-radar-loader loading-radar loading-radar-small" aria-hidden="true"><span></span></div>
+      <strong>${t("butcherLoadingMessage")}</strong>
+      <p class="small loading-dots"><span>.</span><span>.</span><span>.</span></p>
+    </div>
+  `;
+}
+
+function formatDistance(distanceKm) {
+  const formatted = distanceKm.toFixed(1);
+  return state.lang === "he" ? `${formatted} ק״מ` : `${formatted} km`;
+}
+
+function showToast(message) {
+  if (!el.toast) return;
+  el.toast.textContent = message;
+  el.toast.classList.add("is-visible");
+  if (toastTimer) window.clearTimeout(toastTimer);
+  toastTimer = window.setTimeout(() => {
+    el.toast.classList.remove("is-visible");
+  }, 1800);
 }
 
 initOpeningAnimation();

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -44,6 +44,7 @@
       <button id="nextBtn" class="btn btn-primary" type="button"></button>
     </nav>
   </main>
+  <div id="appToast" class="app-toast" role="status" aria-live="polite"></div>
 
   <script src="/app/app.js" defer></script>
 </body>


### PR DESCRIPTION
### Motivation
- Prevent the opening promo from cutting off early and make the intro feel intentional and polished. 
- Provide clear branded loading states for recipe generation and butcher lookup so users never see empty or static wait screens. 
- Make servings adjustments immediate and inline to keep flow smooth and avoid external prompts. 
- Improve RTL shopping rows, butcher distance visibility, My Recipes thumbnails, save confirmation, and map/button legibility while preserving the current flow and theme.

### Description
- Intro / opening: extended the intro minimum duration to ~2.6s, smoothed messaging/step progression and progress bar pacing, and ensured a clean fade-out before teardown (`public/app/app.js`, `public/app/index.html`).
- Loaders & toasts: added branded recipe and butcher loading states with rotating short messages, radar/fire visuals, and a small loading-dots animation; replaced the save `alert()` with an in-app toast that auto-dismisses (`public/app/app.js`, `public/app/app.css`, `public/app/index.html`).
- Servings, shopping RTL & thumbnails: replaced the prompt with inline `− / +` servings controls in Preferences and Recipe screens, updated shopping list rows so checkboxes render left / ingredient text right for RTL, added thumbnail support and saved-recipe fallback thumbnails (`public/app/app.js`, `public/app/app.css`).
- Butcher/map refinements: slightly brightened the butcher map layer, improved the “Open in Maps / פתח במפות” button padding/centered layout and removed underline, added distance labeling with API fallback to a haversine geolocation calculation when coordinates are available (`public/app/app.js`, `public/app/app.css`).

### Testing
- Ran `node --check public/app/app.js` and the file passed syntax checks (OK). 
- Verified repository status with `git status --short` and committed the changes; no changes outside `public/app/` were made.
- No automated UI/browser screenshot tests were available in this environment (visual verification recommended in-device/emulator).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc3671588832facd90070130469b4)